### PR TITLE
Allow users config to override the default config.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,7 @@ var extend = require('extend');
 function config(root) {
   var configFile = path.join(root, 'config', 'coverage-config.js');
   if (fs.existsSync(configFile)) {
-    return extend({}, require(configFile), defaultConfig());
+    return extend({}, defaultConfig(), require(configFile));
   } else {
     return defaultConfig();
   }


### PR DESCRIPTION
Without this change, it is not possible to customize any of the default values (because any customizations are clobbered by the default config).