### PR TITLE
WIP: add external coverage support (coveralls)

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var BroccoliMergeTrees = require('broccoli-merge-trees');
 var CoverageInstrumenter = require('./lib/coverage-instrumenter');
 var attachMiddleware = require('./lib/attach-middleware');
 var config = require('./lib/config');
+var pathFixer = require('./lib/path-fixer');
 
 module.exports = {
   name: 'ember-cli-code-coverage',
@@ -22,9 +23,12 @@ module.exports = {
   postprocessTree: function(type, tree) {
     if (this._coverageIsEnabled() && type === 'js') {
       var appFiles = new Funnel(tree, {
-        exclude: this._config().excludes
+        exclude: this._getExcludes()
       });
-      var instrumentedNode = new CoverageInstrumenter(appFiles, {annotation: 'Instrumenting for code coverage'});
+      var instrumentedNode = new CoverageInstrumenter(appFiles, {
+        annotation: 'Instrumenting for code coverage',
+        app: this.app
+      });
       return new BroccoliMergeTrees([tree, instrumentedNode], { overwrite: true });
     }
     return tree;
@@ -42,6 +46,24 @@ module.exports = {
   },
   _config: function() {
     return config(this.project.root);
+  },
+  _getExcludes: function() {
+    var excludes = this._config().excludes;
+
+    var _this = this;
+    excludes.push(function(relativePath) {
+      relativePath = pathFixer.fixPath(relativePath, _this.app);
+
+      // filters out files that don't exist on disk (come from an addon)
+      try {
+        fs.statSync(relativePath);
+      } catch (err) {
+        return true;
+      }
+
+      return false;
+    });
+
+    return excludes;
   }
 };
-

--- a/lib/coverage-instrumenter.js
+++ b/lib/coverage-instrumenter.js
@@ -2,11 +2,13 @@
 
 var Filter = require('broccoli-filter');
 var Istanbul = require('istanbul');
+var pathFixer = require('./path-fixer');
 
 CoverageInstrumenter.prototype = Object.create(Filter.prototype);
 CoverageInstrumenter.prototype.constructor = CoverageInstrumenter;
 function CoverageInstrumenter(inputNode, options) {
   options = options || {};
+  this._app = options.app;
   Filter.call(this, inputNode, {
     annotation: options.annotation
   });
@@ -21,6 +23,9 @@ CoverageInstrumenter.prototype.processString = function(content, relativePath) {
     esModules: true,
     noAutoWrap: true
   });
+
+  // fixes the path so the lcov.info can be read by 3rd parties (like coveralls)
+  relativePath = pathFixer.fixPath(relativePath, this._app);
 
   return instrumenter.instrumentSync(content, relativePath);
 };

--- a/lib/path-fixer.js
+++ b/lib/path-fixer.js
@@ -1,0 +1,10 @@
+var path = require('path');
+
+module.exports = {
+  fixPath: function(relativePath, app) {
+    var srcDir = path.normalize(relativePath).split(path.sep)[0];
+    var destDir = app.constructor.name === 'EmberApp' ? 'app' : 'addon';
+
+    return relativePath.replace(srcDir, destDir);
+  }
+};


### PR DESCRIPTION
Resolves both #7 and #8, although probably not the right implementation. It involves:
* checking if the file exists, to remove all the files that came in from addons
* changing the path in "lcov.info" so that the paths are "real" enough for coveralls to find them