### PR TITLE
Avoid requiring jQuery for sending the coverage report back.

### DIFF
--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -3,37 +3,37 @@
     var coverageData = window.__coverage__;
     var data = JSON.stringify(coverageData || {});
 
-    $.ajax({
-      type: 'POST',
-      async: false,
-      url: '/write-coverage',
-      datatype: 'json',
-      contentType:'application/json; charset=utf-8',
-      data: data,
-      error: function(jqXHR, textStatus, errorThrown ) {
-        throw errorThrown;
-      },
-      success: function(data) {
-        if (!data || !data.total) {
-          return;
-        }
+    var request = new XMLHttpRequest();
+    request.open('POST', '/write-coverage', true);
+    request.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+    request.send(data);
+    request.responseType = 'json';
 
-        var results = ['Lines', 'Branches', 'Functions', 'Statements']
-          .filter(function (name) {
-            return data.total[name.toLowerCase()]
-          })
-          .map(function (name) {
-            return name + ' ' + data.total[name.toLowerCase()].pct + '%'
-          })
+    request.onload = function() {
+      var data = this.response;
 
-        $('body').append('<div style="background-color: white; color: black; border: 2px solid black; padding: 1em;position: fixed; left: 15px; bottom: 15px">' + results.join(' | ') + '</div>');
-      },
-      complete: function() {
-        if (callback) {
-          callback();
-        }
+      if (!data || !data.total) {
+        return;
       }
-    });
+
+      var results = ['Lines', 'Branches', 'Functions', 'Statements']
+        .filter(function (name) {
+          return data.total[name.toLowerCase()]
+        })
+        .map(function (name) {
+          return name + ' ' + data.total[name.toLowerCase()].pct + '%'
+        });
+
+      var resultsText = document.createTextNode(results.join(' | '));
+      var element = document.createElement('div');
+      element.style = 'background-color: white; color: black; border: 2px solid black; padding: 1em;position: fixed; left: 15px; bottom: 15px';
+      element.appendChild(resultsText);
+      document.body.appendChild(element);
+
+      if (callback) {
+        callback();
+      }
+    };
   }
 
   if (typeof Testem !== "undefined" && Testem.afterTests) {


### PR DESCRIPTION
Works the same:

![screenshot](https://monosnap.com/file/mTBQ7FipcmdnXbG8Tkc0XxhpCQsXM1.png)

And doesn't troll apps running without jQuery (don't ask yet if that is
a thing plz :wink: ).