### PR TITLE
Fix hang when running in PhantomJS.

### DIFF
--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -12,6 +12,11 @@
     request.onload = function() {
       var data = this.response;
 
+      // PhantomJS doesn't honor `responseType = 'json'`
+      if (typeof data === 'string') {
+        data = JSON.parse(data);
+      }
+
       if (!data || !data.total) {
         return;
       }


### PR DESCRIPTION
In trying to diagnose why tests hang when trying to report coverage with PhantomJS, I realized `this.response` was coming back as a string rather than a parsed object after posting the coverage information.

It turns out (as far as I can tell), Phantom just doesn't honor `xhr.responseType = 'json'`, and if you read it back, you just get `''`. To convince myself I wasn't going crazy, I captured result of loading [this page](https://mathiasbynens.be/demo/json-responsetype) in Phantom 2.1, and it looks like this:
![result](https://cloud.githubusercontent.com/assets/108688/18647608/b782edf6-7e84-11e6-90ab-46f99dd68e0c.png)

Adding an explicit `JSON.parse` avoids the early return so that the Testem callback gets invoked and everything cleans up correctly.

I'm not sure how (or whether) to test this; any input on that is welcome. Thanks!