### PR TITLE
Handle addons with different package names

### DIFF
--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -249,13 +249,13 @@ describe('index.js', function() {
     });
   });
 
-  describe('_getEcludes', function() {
+  describe('_getExcludes', function() {
     beforeEach(function() {
       sandbox.stub(Index, '_filterOutAddonFiles').returns('test');
 
       Index.parent = {
-        pkg: {
-          name: 'foo-bar'
+        isEmberCLIAddon: function() {
+          return false;
         }
       };
     });
@@ -395,6 +395,63 @@ describe('index.js', function() {
       it('returns false', function() {
         expect(Index._isCoverageEnabled()).to.be.false;
       });
+    });
+  });
+
+  describe('_parentName', function() {
+    var isAddon;
+
+    beforeEach(function() {
+      Index.parent = {
+        name: 'parent-app',
+        isEmberCLIAddon: function() {
+          return isAddon;
+        }
+      };
+    });
+
+    describe('when parent is an app', function() {
+      beforeEach(function() {
+        isAddon = false;
+      });
+
+      it('returns the app name', function() {
+        expect(Index._parentName()).to.equal('parent-app');
+      });
+    });
+
+    describe('when parent is an addon', function() {
+      beforeEach(function() {
+        isAddon = true;
+        sandbox.stub(Index, '_findCoveredAddon').returns({ name: 'some-addon' });
+      });
+
+      it('returns the addon name', function() {
+        expect(Index._parentName()).to.equal('some-addon');
+      });
+    });
+  });
+
+  describe('_findCoveredAddon', function() {
+    var result;
+
+    beforeEach(function() {
+      Index.project = {
+        findAddonByName: sinon.stub().returns({ name: 'my-addon' }),
+        pkg: {
+          name: '@scope/ember-cli-my-addon'
+        }
+      };
+
+      result = Index._findCoveredAddon();
+    });
+
+    it('looks up the addon by the package name', function() {
+      expect(Index.project.findAddonByName.calledWith('@scope/ember-cli-my-addon')).to.be.true;
+    });
+
+    it('returns the located addon', function() {
+      expect(result.name).to.equal('my-addon');
     });
   });
 });


### PR DESCRIPTION
This should fix #45, where addons whose name is different from the one in their `package.json` don't get coverage.