### PR TITLE
return actual name not function from _parentName

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ module.exports = {
     if (this.parent.isEmberCLIAddon()) {
       return this._findCoveredAddon().name;
     } else {
-      return this.parent.name;
+      return this.parent.pkg.name;
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ module.exports = {
     if (this.parent.isEmberCLIAddon()) {
       return this._findCoveredAddon().name;
     } else {
-      return this.parent.pkg.name;
+      return this.parent.name();
     }
   },
 

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -256,6 +256,9 @@ describe('index.js', function() {
       Index.parent = {
         isEmberCLIAddon: function() {
           return false;
+        },
+        name: function() {
+          return 'test';
         }
       };
     });
@@ -403,7 +406,9 @@ describe('index.js', function() {
 
     beforeEach(function() {
       Index.parent = {
-        name: 'parent-app',
+        name: function() {
+          return 'parent-app';
+        },
         isEmberCLIAddon: function() {
           return isAddon;
         }


### PR DESCRIPTION
this.parent.name is a function (if defined), this.parent.pkg.name is the expected name of the package.
Using 0.3.3 I get no coverage for any files in the app. (worked in 0.3.2)