### PR TITLE
Cosmetics for docs, renamed function name and parameter name

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,21 +124,23 @@ module.exports = {
 
     return this._doesTemplateFileExist(relativePath);
   },
-    /**
+  
+  /**
    * Check if a file exists within the current addon directory. Removing `module/<app-name>` from the path.
    * @param {String} relativePath - path to file within current app
    * @returns {Boolean} whether or not the file exists within the current app
    */
-  _doesFileExistIsCurrentProjectAddonModule: function(_relativePath) {
-    var relativePathWithoutProjectNamePrefix = _relativePath.replace('modules' + '/' +  this._parentName(), '');
-    var relativePath = 'addon/' + relativePathWithoutProjectNamePrefix;
+  _doesFileExistInCurrentProjectAddonModule: function(relativePath) {
+    var relativePathWithoutProjectNamePrefix = relativePath.replace('modules' + '/' +  this._parentName(), '');
+    var _relativePath = 'addon/' + relativePathWithoutProjectNamePrefix;
 
-    if (this._existsSync(relativePath)) {
+    if (this._existsSync(_relativePath)) {
       return true;
     }
 
-    return this._doesTemplateFileExist(relativePath);
+    return this._doesTemplateFileExist(_relativePath);
   },
+  
   /**
    * Check if a file exists within the dummy app
    * @param {String} relativePath - path to file within dummy app
@@ -204,7 +206,7 @@ module.exports = {
       this._doesFileExistInDummyApp(relativePath) ||
       this._doesFileExistInCurrentProjectApp(relativePath) ||
       this._doesFileExistInCurrentProjectAddon(relativePath) ||
-       this._doesFileExistIsCurrentProjectAddonModule(relativePath)
+      this._doesFileExistInCurrentProjectAddonModule(relativePath)
     );
 
     return !fileExists;

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = {
 
     return this._doesTemplateFileExist(relativePath);
   },
-  
+
   /**
    * Check if a file exists within the current addon directory. Removing `module/<app-name>` from the path.
    * @param {String} relativePath - path to file within current app
@@ -140,7 +140,7 @@ module.exports = {
 
     return this._doesTemplateFileExist(_relativePath);
   },
-  
+
   /**
    * Check if a file exists within the dummy app
    * @param {String} relativePath - path to file within dummy app


### PR DESCRIPTION
Renamed `_doesFileExistIsCurrentProjectAddonModule` to
`_doesFileExistInCurrentProjectAddonModule` and its parameter from
`_relativePath` to `relativePath` to make is consistent with other
`_doesFileExist...`-functions. Cosmetics only, no functional changes.