### PR TITLE
Add ability to pass addonName and fix paths

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/* jshint ignore:start */
 module.exports = {
   root: true,
   extends: 'eslint:recommended',
@@ -95,3 +96,4 @@ module.exports = {
     'comma-dangle': 0,
   },
 };
+/* jshint ignore:end */

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Configuration is optional. It should be put in a file at `config/coverage.js`.
 
 #### Options
 
+- `addonName`: Defaults to `null`. This is a string specifying the name of your addon, i.e `'my-ember-addon'`. This allows for correcting files paths for tools like Code Climate and Coveralls.
+
 - `coverageEnvVar`: Defaults to `COVERAGE`. This is the environment variable that when set will cause coverage metrics to be generated.
 
 - `reporters`: Defaults to `['lcov', 'html']`. The `json-summary` reporter will be added to anything set here, it is required. This can be any [reporters supported by Istanbul](https://github.com/gotwarlost/istanbul/tree/master/lib/report).

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ Configuration is optional. It should be put in a file at `config/coverage.js`.
 
 #### Options
 
-- `addonName`: Defaults to `null`. This is a string specifying the name of your addon, i.e `'my-ember-addon'`. This allows for correcting files paths for tools like Code Climate and Coveralls.
-
 - `coverageEnvVar`: Defaults to `COVERAGE`. This is the environment variable that when set will cause coverage metrics to be generated.
 
 - `reporters`: Defaults to `['lcov', 'html']`. The `json-summary` reporter will be added to anything set here, it is required. This can be any [reporters supported by Istanbul](https://github.com/gotwarlost/istanbul/tree/master/lib/report).

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -22,12 +22,12 @@ module.exports = function(app, options) {
 
       // If we define an addonName, strip modules/addonName and replace with 'addon'
       if (_config.addonName) {
-        for (var key of Object.keys(req.body)) {
+        Object.keys(req.body).forEach(function(key) {
           if (key.includes('modules/' + _config.addonName)) {
             req.body[key].path = req.body[key].path
               .replace(new RegExp('modules/' + _config.addonName, 'g'), 'addon');
           }
-        }
+        });
       }
 
       collector.add(req.body);

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -22,10 +22,10 @@ module.exports = function(app, options) {
 
       // If we define an addonName, strip modules/addonName and replace with 'addon'
       if (_config.addonName) {
+        var regex = new RegExp('modules/' + _config.addonName, 'g');
         Object.keys(req.body).forEach(function(key) {
           if (key.includes('modules/' + _config.addonName)) {
-            req.body[key].path = req.body[key].path
-              .replace(new RegExp('modules/' + _config.addonName, 'g'), 'addon');
+            req.body[key].path = req.body[key].path.replace(regex, 'addon');
           }
         });
       }

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('string.prototype.includes');
+
 var bodyParser = require('body-parser');
 var Istanbul = require('istanbul');
 var config = require('./config');

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -22,7 +22,7 @@ module.exports = function(app, options) {
 
       // If we define an addonName, strip modules/addonName and replace with 'addon'
       if (_config.addonName) {
-        for (const key of Object.keys(req.body)) {
+        for (var key of Object.keys(req.body)) {
           if (key.includes('modules/' + _config.addonName)) {
             req.body[key].path = req.body[key].path
               .replace(new RegExp('modules/' + _config.addonName, 'g'), 'addon');

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -20,6 +20,16 @@ module.exports = function(app, options) {
       var reporter = new Istanbul.Reporter(null, path.join(options.root, _config.coverageFolder));
       var sync = false;
 
+      // If we define an addonName, strip modules/addonName and replace with 'addon'
+      if (_config.addonName) {
+        for (const key of Object.keys(req.body)) {
+          if (key.includes('modules/' + _config.addonName)) {
+            req.body[key].path = req.body[key].path
+              .replace(new RegExp('modules/' + _config.addonName, 'g'), 'addon');
+          }
+        }
+      }
+
       collector.add(req.body);
 
       if (_config.reporters.indexOf('json-summary') === -1) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -36,6 +36,7 @@ function config(root) {
  */
 function getDefaultConfig() {
   return {
+    addonName: null,
     coverageEnvVar: 'COVERAGE',
     coverageFolder: 'coverage',
     excludes: [

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,15 @@ function config(root) {
   var configFile = path.join(root, 'config', 'coverage.js');
   var defaultConfig = getDefaultConfig();
 
+  var packageJson = require(path.join(root, 'package.json'));
+  var isAddon = packageJson.keywords && packageJson.keywords.indexOf('ember-addon') > -1;
+
+  if (isAddon) {
+    defaultConfig = extend({}, defaultConfig, {
+      addonName: packageJson.name
+    });
+  }
+
   if (fs.existsSync(configFile)) {
     var projectConfig = require(configFile);
     return extend({}, defaultConfig, projectConfig);
@@ -36,7 +45,6 @@ function config(root) {
  */
 function getDefaultConfig() {
   return {
-    addonName: null,
     coverageEnvVar: 'COVERAGE',
     coverageFolder: 'coverage',
     excludes: [

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "extend": "^3.0.0",
     "fs-extra": "^0.26.7",
     "istanbul": "^0.4.3",
-    "source-map": "0.5.6"
+    "source-map": "0.5.6",
+    "string.prototype.includes": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
This allows passing `addonName` in the config and it will replace `modules/my-addon` with `addon` in the lcov.info file. This should allow proper file mapping for things like Code Climate and Coveralls. Does this approach look okay to you @rwjblue and @kategengler?

Resolves #36 
