### PR TITLE
Avoid throwing errors while requiring files for coverage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
   fast_finish: true
   include:
   - node_js: "6"
+    env: NPM_SCRIPT=browser-test
+  - node_js: "6"
     env: NPM_SCRIPT=jscs
   - node_js: "6"
     env: NPM_SCRIPT=lint

--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -6,8 +6,8 @@
       if (parts[0] === '{%PROJECT_NAME%}' && parts[1] !== 'tests') {
         try {
           require(file);
-        } catch(e) {
-          throw 'error requiring file for coverage: '+file;
+        } catch(error) {
+          console.warn('Error occurred while evaluating `' + file + '`: ' + error.message + '\n' + error.stack);
         }
       }
     });

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "node-test": "mocha test/**/*-test.js",
+    "browser-test": "COVERAGE=true ember test",
     "lint": "eslint config lib test tests *.js",
     "jscs": "jscs lib test",
     "test": "npm run-script jscs && npm run-script lint && npm run-script node-test"

--- a/tests/unit/handle-modules-throwing-on-import-test.js
+++ b/tests/unit/handle-modules-throwing-on-import-test.js
@@ -1,0 +1,17 @@
+/* global define */
+import { module, test } from 'qunit';
+
+
+module('invalid modules');
+
+test('noop to setup module for exit handler', function(assert) {
+  assert.expect(0);
+
+  define('ember-cli-code-coverage/fake-module-from-unit-test', [], function() {
+    // This exists to confirm that modules that throw errors during
+    // eval, do not fail the build
+    //
+    // See https://github.com/kategengler/ember-cli-code-coverage/issues/63 for details.
+    throw new Error('Error thrown on import!');
+  });
+});


### PR DESCRIPTION
To ensure coverage percentages are accurate we added some code to automatically require all modules in the application/addon.  If an error was detected while loading the module we annotated it with information on why it occurred, but still rethrew the error. 

In retrospect, it seems that a number of applications have dormant (and invalid) modules that exist in the app (at least during tests).  Our prior concept/assertion that rethrowing an error was the correct path turns out to itself be painful.

This changes that error into a warning (because I truly believe we should encourage folks to fix these scenarios).

Fixes https://github.com/kategengler/ember-cli-code-coverage/issues/63.