### PR TITLE
Refactor add-on renaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports = {
       appName: this._parentName(),
       appRoot: this.parent.root,
       babelOptions: this.app.options.babel,
+      isAddon: this.project.isEmberCLIAddon(),
       useBabelInstrumenter: useBabelInstrumenter,
       templateExtensions: this.registry.extensionsForType('template')
     });

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('string.prototype.includes');
-
 var bodyParser = require('body-parser');
 var Istanbul = require('istanbul');
 var config = require('./config');
@@ -21,16 +19,6 @@ module.exports = function(app, options) {
       var _config = config(options.root);
       var reporter = new Istanbul.Reporter(null, path.join(options.root, _config.coverageFolder));
       var sync = false;
-
-      // If we define an addonName, strip modules/addonName and replace with 'addon'
-      if (_config.addonName) {
-        var regex = new RegExp('modules/' + _config.addonName, 'g');
-        Object.keys(req.body).forEach(function(key) {
-          if (key.includes('modules/' + _config.addonName)) {
-            req.body[key].path = req.body[key].path.replace(regex, 'addon');
-          }
-        });
-      }
 
       collector.add(req.body);
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,15 +22,6 @@ function config(root) {
   var configFile = path.join(root, 'config', 'coverage.js');
   var defaultConfig = getDefaultConfig();
 
-  var packageJson = require(path.join(root, 'package.json'));
-  var isAddon = packageJson.keywords && packageJson.keywords.indexOf('ember-addon') > -1;
-
-  if (isAddon) {
-    defaultConfig = extend({}, defaultConfig, {
-      addonName: packageJson.name
-    });
-  }
-
   if (fs.existsSync(configFile)) {
     var projectConfig = require(configFile);
     return extend({}, defaultConfig, projectConfig);

--- a/lib/coverage-instrumenter.js
+++ b/lib/coverage-instrumenter.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('string.prototype.includes');
 var existsSync = require('exists-sync');
 var extend = require('extend');
 var Filter = require('broccoli-filter');
@@ -24,25 +25,35 @@ function getPathForRealFile(relativePath, root, templateExtensions) {
   return null;
 }
 
-function fixPath(relativePath, name, root, templateExtensions) {
+function fixPath(relativePath, name, root, templateExtensions, isAddon) {
   // Handle apps (served from app name)
-  if (relativePath.indexOf(name) === 0) {
-    relativePath = relativePath.replace(name, 'app')
-    return getPathForRealFile(relativePath, root, templateExtensions) || relativePath
+  if (!isAddon && relativePath.includes(name)) {
+    relativePath = relativePath.replace(name, 'app');
+    return getPathForRealFile(relativePath, root, templateExtensions) || relativePath;
   }
 
   // Handle addons (served from dummy app)
-  if (relativePath.indexOf('dummy') === 0) {
-    relativePath = relativePath.replace('dummy', 'app')
-    var dummyPath = path.join('tests', 'dummy', relativePath)
+  if (relativePath.includes('dummy')) {
+    relativePath = relativePath.replace('dummy', 'app');
+    var dummyPath = path.join('tests', 'dummy', relativePath);
     return (
       getPathForRealFile(dummyPath, root, templateExtensions) ||
       getPathForRealFile(relativePath, root, templateExtensions) ||
       relativePath
-    )
+    );
   }
 
-  return relativePath
+  // Handle addons renaming of modules/my-addon
+  if (isAddon && relativePath.includes('modules/' + name)) {
+    var regex = new RegExp('modules/' + name, 'g');
+    relativePath = relativePath.replace(regex, 'addon');
+    return (
+      getPathForRealFile(relativePath, root, templateExtensions) ||
+      relativePath
+    );
+  }
+
+  return relativePath;
 }
 
 CoverageInstrumenter.prototype = Object.create(Filter.prototype);
@@ -52,6 +63,7 @@ function CoverageInstrumenter(inputNode, options) {
 
   this._appName = options.appName;
   this._appRoot = options.appRoot;
+  this._isAddon = options.isAddon;
   this._useBabelInstrumenter = options.useBabelInstrumenter;
 
   this._babelOptions = extend({
@@ -95,8 +107,7 @@ CoverageInstrumenter.prototype.processString = function(content, relativePath) {
     });
   }
 
-
-  relativePath = fixPath(relativePath, this._appName, this._appRoot, this._templateExtensions);
+  relativePath = fixPath(relativePath, this._appName, this._appRoot, this._templateExtensions, this._isAddon);
 
   try {
     return instrumenter.instrumentSync(content, relativePath);

--- a/lib/coverage-instrumenter.js
+++ b/lib/coverage-instrumenter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-require('string.prototype.includes');
+require('string.prototype.startswith');
 var existsSync = require('exists-sync');
 var extend = require('extend');
 var Filter = require('broccoli-filter');
@@ -26,31 +26,31 @@ function getPathForRealFile(relativePath, root, templateExtensions) {
 }
 
 function fixPath(relativePath, name, root, templateExtensions, isAddon) {
-  // Handle apps (served from app name)
-  if (!isAddon && relativePath.includes(name)) {
+  // Handle addons
+  if (isAddon) {
+    // Handle addons (served from dummy app)
+    if (relativePath.startsWith('dummy')) {
+      relativePath = relativePath.replace('dummy', 'app');
+      var dummyPath = path.join('tests', 'dummy', relativePath);
+      return (
+        getPathForRealFile(dummyPath, root, templateExtensions) ||
+        getPathForRealFile(relativePath, root, templateExtensions) ||
+        relativePath
+      );
+    }
+
+    // Handle addons renaming of modules/my-addon
+    if (relativePath.startsWith('modules/' + name)) {
+      var regex = new RegExp('^modules/' + name);
+      relativePath = relativePath.replace(regex, 'addon');
+      return (
+        getPathForRealFile(relativePath, root, templateExtensions) ||
+        relativePath
+      );
+    }
+  } else {
     relativePath = relativePath.replace(name, 'app');
     return getPathForRealFile(relativePath, root, templateExtensions) || relativePath;
-  }
-
-  // Handle addons (served from dummy app)
-  if (relativePath.includes('dummy')) {
-    relativePath = relativePath.replace('dummy', 'app');
-    var dummyPath = path.join('tests', 'dummy', relativePath);
-    return (
-      getPathForRealFile(dummyPath, root, templateExtensions) ||
-      getPathForRealFile(relativePath, root, templateExtensions) ||
-      relativePath
-    );
-  }
-
-  // Handle addons renaming of modules/my-addon
-  if (isAddon && relativePath.includes('modules/' + name)) {
-    var regex = new RegExp('modules/' + name, 'g');
-    relativePath = relativePath.replace(regex, 'addon');
-    return (
-      getPathForRealFile(relativePath, root, templateExtensions) ||
-      relativePath
-    );
   }
 
   return relativePath;

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "fs-extra": "^0.26.7",
     "istanbul": "^0.4.3",
     "source-map": "0.5.6",
-    "string.prototype.includes": "^1.0.0"
+    "string.prototype.startswith": "^0.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Moved from attach-middleware to coverage-instrumenter, where the other path fixing occurs. Resolves #67 