### PR TITLE
Set sync to true, to make nested files work

### DIFF
--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -18,7 +18,7 @@ module.exports = function(app, options) {
       var collector = new Istanbul.Collector();
       var _config = config(options.root);
       var reporter = new Istanbul.Reporter(null, path.join(options.root, _config.coverageFolder));
-      var sync = false;
+      var sync = true;
 
       collector.add(req.body);
 


### PR DESCRIPTION
@rwjblue had a magical suggestion of setting `sync` to `true`, as he thought perhaps express was timing out here, and it seems to have done the trick.

This change gets nested coverage html files generated. Some were being skipped without this.