### PR TITLE
Restrict branches for builds, use preinstalled Chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,11 @@ node_js:
 dist: trusty
 sudo: required
 
-addons:
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+branches:
+  only:
+    - master
+    - auto
+    - /^greenkeeper.*$/
 
 cache:
   directories:
@@ -26,15 +25,14 @@ matrix:
   fast_finish: true
   include:
   - node_js: "6"
-    env: NPM_SCRIPT=browser-test
-  - node_js: "6"
     env: NPM_SCRIPT=lint
 
 before_install:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - npm config set spin false
+  - npm install -g npm@^2
 
 install:
   - npm install -g bower


### PR DESCRIPTION
This should hopefully stop us from having multiple PR builds, and should use the Chrome available already on Travis, rather than installing it again.