### PR TITLE
Fix phantomjs `request aborted` edge case

### DIFF
--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -1,4 +1,6 @@
 <script>
+  // Make synchronous requests in phantom to avoid killing the runner before the coverage completes.
+  var REQUEST_ASYNC = !/PhantomJS/.test(window.navigator.userAgent);
   function sendCoverage(callback) {
    Object.keys(require.entries).forEach(function(file) {
       // Only load non-test files from the project
@@ -16,7 +18,7 @@
     var data = JSON.stringify(coverageData || {});
 
     var request = new XMLHttpRequest();
-    request.open('POST', '/write-coverage', true);
+    request.open('POST', '/write-coverage', REQUEST_ASYNC);
     request.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
     request.send(data);
     request.responseType = 'json';


### PR DESCRIPTION
I experienced a difficult to reproduce edge case on an Ember application with > 500 tests:

When running with coverage on the v0.3.8 tag, my test server crashes right after the tests complete with the following error:

```
Error: request aborted
    at IncomingMessage.onAborted ([snip]/ember-cli-code-coverage/node_modules/raw-body/index.js:269:10)
    at emitNone (events.js:86:13)
    at IncomingMessage.emit (events.js:185:7)
    at abortIncoming (_http_server.js:283:11)
    at Socket.serverSocketCloseListener (_http_server.js:296:5)
    at emitOne (events.js:101:20)
    at Socket.emit (events.js:188:7)
    at TCP._handle.close [as _onclose] (net.js:498:12)
```

This wasn't happening on the version we were using before (v0.2.2), so I figured it was a change in the recent minor bumps that caused the breakage. I bisected tags, and reproduced the issue in v0.3.7 and not v0.3.5 (v0.3.6 doesn't work with our codebase at all due to a throw that was downgraded to a warn in v0.3.7).

Looking at the [compare between those versions](https://github.com/kategengler/ember-cli-code-coverage/compare/v0.3.5...v0.3.7), I couldn't see anything that looked even the slightest bit innocuous, so I started a long and fruitless journey through ember-cli, testem, and friends to try to see if I could pin down a source anywhere.

I also set up a new ember application and prodded it for a good amount of time looking for a repro case to no avail. Unfortunately it's a consistent error in a private repo (every jenkins build since I bumped ember-cli-code-coverage has broken along with local builds), but I have no repro case to offer.

As an additional annoyance, I was unsuccessful (in a workday) in finding the *real* source of the issue in the testem flow, but can say with certainty that it is *not* caused by:

• a long timeout on the /write-coverage endpoint
• onload use rather than readystatechange events
• calling the sendCoverage callback in the same event loop as the coverage XHR onload event (I tried setting various timeouts before calling callback, same result)

The only difference I could find in my large suite vs a brand new one was the fact that (oddly), `Testem` was emitting `'all-test-results'` multiple (3) times. I figured this was the issue (it resolves the first XHR with 3 in flight, and the second one is cancelled by a disconnect). However, I was unable to fix this by only allowing `sendCoverage` to be called once, leading me to believe that either my suite is spinning up multiple runners, or the issue is unrelated (or in an alternative listener).

Through this exploration, I found a few different ways to workaround the failure, the simplest of which being contained in this PR (just make the XHR sync when inside PhantomJS) .

I'm almost 100% certain the issue I'm experiencing is *not* caused by this repo, but this seems like the most reasonable place to add a workaround in lieu of fixing the root cause in a dependency lib, since the use case (sending an XHR from test-body-footer.html on test complete) is fairly esoteric and hunting down the root cause is likely going to take longer than I have available to work on this case.