### PR TITLE
Fixes #42 use configPath instead of hard-coded config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When running with `parallel` set to true, the final reports can be merged by usi
 
 ## Configuration
 
-Configuration is optional. It should be put in a file at `config/coverage.js`. 
+Configuration is optional. It should be put in a file at `config/coverage.js` (`configPath` configuration in package.json is honored)
 
 #### Options
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ module.exports = {
 
   testemMiddleware: function(app) {
     if (!this._isCoverageEnabled()) { return; }
-    attachMiddleware(app, { root: this.project.root, ui: this.ui });
+    attachMiddleware(app, { configPath: this.project.configPath(), root: this.project.root });
   },
 
   // Custom Methods
@@ -204,7 +204,7 @@ module.exports = {
    * @returns {Configuration} project configuration
    */
   _getConfig: function() {
-    return config(this.project.root);
+    return config(this.project.configPath());
   },
 
   /**

--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -17,7 +17,7 @@ module.exports = function(app, options) {
     bodyParser.json({ limit: '50mb' }),
     function(req, res) {
       var collector = new Istanbul.Collector();
-      var _config = config(options.root);
+      var _config = config(options.configPath);
 
       if (_config.parallel) {
         _config.coverageFolder = _config.coverageFolder + '_' + crypto.randomBytes(4).toString('hex');

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,11 +15,12 @@ var path = require('path');
 /**
  * Get configuration for a project, falling back to default configuration if
  * project does not provide a configuration of its own
- * @param {String} root - root path of project
+ * @param {String} configPath - The path for the configuration of the project
  * @returns {Configuration} configuration to use for project
  */
-function config(root) {
-  var configFile = path.join(root, 'config', 'coverage.js');
+function config(configPath) {
+  var configDirName = path.dirname(configPath);
+  var configFile = path.resolve(path.join(configDirName, 'coverage.js'));
   var defaultConfig = getDefaultConfig();
 
   if (fs.existsSync(configFile)) {

--- a/lib/coverage-merge.js
+++ b/lib/coverage-merge.js
@@ -51,6 +51,6 @@ module.exports = {
    * @returns {Configuration} project configuration
    */
   _getConfig: function () {
-    return config(this.project.root);
+    return config(this.project.configPath());
   }
 };

--- a/test/integration/coverage-test.js
+++ b/test/integration/coverage-test.js
@@ -18,7 +18,7 @@ describe('`ember test`', function() {
   });
 
   afterEach(function() {
-    return remove('config/coverage.js');
+    return remove('tests/dummy/config/coverage.js');
   });
 
   it('runs coverage when env var is set', function() {
@@ -43,7 +43,7 @@ describe('`ember test`', function() {
   it('uses parallel configuration and merges coverage when merge-coverage command is issued', function() {
     this.timeout(100000);
     expect(dir('coverage')).to.not.exist;
-    fs.copySync('config/coverage-parallel.js', 'config/coverage.js');
+    fs.copySync('tests/dummy/config/coverage-parallel.js', 'tests/dummy/config/coverage.js');
     return runCommand('ember', ['exam', '--split=2', '--parallel=true'], {env: {COVERAGE: true}}).then(function() {
       expect(dir('coverage')).to.not.exist;
       return runCommand('ember', ['coverage-merge']);

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -80,7 +80,8 @@ describe('index.js', function() {
       };
 
       Index.project = {
-        root: '/path/to/foo-bar'
+        root: '/path/to/foo-bar',
+        configPath: sinon.stub().returns('tests/dummy/config/environment.js')
       };
     });
 

--- a/tests/dummy/config/coverage-parallel.js
+++ b/tests/dummy/config/coverage-parallel.js
@@ -1,5 +1,4 @@
 /*jshint node:true*/
-'use strict';
 
 module.exports = {
   parallel: true


### PR DESCRIPTION
On this PR I'm trying to tackle the issue brought up in #42 by using `configPath` instead of the hard coded config path value. 

According to the [ember-cli docs](https://ember-cli.com/api/classes/Project.html#method_configPath) `configPath` is private but I couldn't figure out a better/public way to determine this value. If anybody knows of a better way to make this change I'll be happy to integrate the feedback. 