### PR TITLE
WIP: Exclude dummy files

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,14 +189,20 @@ module.exports = {
       relativePath = relativePath.replace('dummy/', '');
     }
 
-    var fileExists = (
-      this._doesFileExistInDummyApp(relativePath) ||
-      this._doesFileExistInCurrentProjectApp(relativePath) ||
-      this._doesFileExistInCurrentProjectAddon(relativePath) ||
-      this._doesFileExistInCurrentProjectAddonModule(relativePath)
-    );
+    var remove;
 
-    return !fileExists;
+    if (this._doesFileExistInDummyApp(relativePath)) {
+      remove = true;
+    } else {
+      remove = !(
+        this._doesFileExistInCurrentProjectApp(relativePath) ||
+        this._doesFileExistInCurrentProjectAddon(relativePath) ||
+        this._doesFileExistInCurrentProjectAddonModule(relativePath)
+      );
+    }
+
+    return remove;
+
   },
 
   /**

--- a/index.js
+++ b/index.js
@@ -191,8 +191,9 @@ module.exports = {
 
     var remove;
 
+    //do default exclude logic
     if (this._doesFileExistInDummyApp(relativePath)) {
-      remove = true;
+      remove = true;  //remove dummy app files by default
     } else {
       remove = !(
         this._doesFileExistInCurrentProjectApp(relativePath) ||
@@ -201,8 +202,16 @@ module.exports = {
       );
     }
 
-    return remove;
+    //do exclude logic from config
+    var shouldIncludeFile = this._getConfig('shouldIncludeFile');
+    if (typeof shouldIncludeFile === 'function') {
+      var shouldInclude = shouldIncludeFile(this.project, relativePath, !remove);
+      if (shouldInclude !== 'null') {
+        remove = !shouldInclude;
+      }
+    }
 
+    return remove;
   },
 
   /**


### PR DESCRIPTION
Relates to issues #41, #71, and #85.  It looks like there is a desire to not include the dummy app files in an add-on.  We also need them excluded.

The desired solution is documented in #76, but there there hasn't been any movement there.  Can a short term solution be implemented to always exclude them?  Or is there a requirement to include them?

The [logic](https://github.com/kategengler/ember-cli-code-coverage/blob/master/index.js#L193) is always including modules in the dummy app rather than excluding them.  This change always excludes them.