### PR TITLE
Add template instrumentation.

### DIFF
--- a/addon/.eslintrc.js
+++ b/addon/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  },
+  extends: 'eslint:recommended',
+  env: {
+    browser: true
+  },
+  rules: {
+  }
+};

--- a/addon/helpers/ember-cli-code-coverage-increment.js
+++ b/addon/helpers/ember-cli-code-coverage-increment.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export function emberCliCodeCoverageIncrement(params, hash) {
+  let { path, statement, branch, condition } = hash;
+
+  if (statement) {
+    window.__coverage__[path].s[statement]++;
+  }
+
+  if (branch && condition) {
+    window.__coverage__[path].b[branch][condition]++;
+  }
+}
+
+export default Ember.Helper.helper(emberCliCodeCoverageIncrement);

--- a/addon/helpers/ember-cli-code-coverage-register.js
+++ b/addon/helpers/ember-cli-code-coverage-register.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export function emberCliCodeCoverageRegister([rawData]) {
+  let coverageData = JSON.parse(rawData);
+  window.__coverage__[coverageData.path] = coverageData;
+}
+
+export default Ember.Helper.helper(emberCliCodeCoverageRegister);

--- a/app/helpers/ember-cli-code-coverage-increment.js
+++ b/app/helpers/ember-cli-code-coverage-increment.js
@@ -1,0 +1,1 @@
+export { default, emberCliCodeCoverageIncrement } from 'ember-cli-code-coverage/helpers/ember-cli-code-coverage-increment';

--- a/app/helpers/ember-cli-code-coverage-register.js
+++ b/app/helpers/ember-cli-code-coverage-register.js
@@ -1,0 +1,1 @@
+export { default, emberCliCodeCoverageRegister } from 'ember-cli-code-coverage/helpers/ember-cli-code-coverage-register';

--- a/index.js
+++ b/index.js
@@ -14,6 +14,18 @@ module.exports = {
 
   // Ember Methods
 
+  setupPreprocessorRegistry: function(type, registry) {
+    if (!this._isCoverageEnabled()) { return; }
+
+    var TemplateInstrumenter = require('./lib/template-instrumenter');
+
+    registry.add('htmlbars-ast-plugin', {
+      name: "template-instrumenter",
+      plugin: TemplateInstrumenter,
+      baseDir: __dirname
+    });
+  },
+
   included: function() {
     if (this._isCoverageEnabled() && this.parent.isEmberCLIAddon()) {
       var coveredAddon = this._findCoveredAddon();

--- a/index.js
+++ b/index.js
@@ -17,7 +17,13 @@ module.exports = {
   setupPreprocessorRegistry: function(type, registry) {
     if (!this._isCoverageEnabled()) { return; }
 
-    var TemplateInstrumenter = require('./lib/template-instrumenter');
+    const buildTemplateInstrumenter = require('./lib/template-instrumenter');
+    let TemplateInstrumenter = buildTemplateInstrumenter(
+      this._parentName(),
+      this.parent.root,
+      this.registry.extensionsForType('template'),
+      this.project.isEmberCLIAddon()
+    );
 
     registry.add('htmlbars-ast-plugin', {
       name: "template-instrumenter",

--- a/lib/coverage-instrumenter.js
+++ b/lib/coverage-instrumenter.js
@@ -117,3 +117,4 @@ CoverageInstrumenter.prototype.processString = function(content, relativePath) {
 };
 
 module.exports = CoverageInstrumenter;
+module.exports.fixPath = fixPath;

--- a/lib/template-instrumenter.js
+++ b/lib/template-instrumenter.js
@@ -1,0 +1,173 @@
+'use strict';
+
+const LINE_ENDINGS = /(?:\r\n?|\n)/;
+
+module.exports = class IstanbulInstrumenter {
+  constructor(options) {
+
+    this.options = options;
+    this.moduleName = options.meta && options.meta.moduleName;
+
+    this.coverageData = {
+      path: this.moduleName,
+      s: { },
+      b: { },
+      f: { },
+      fnMap: { },
+      statementMap: { },
+      branchMap: { },
+      code: [ ]
+    };
+
+    this._currentStatement = 0;
+    this._currentBranch = 0;
+
+    if (options.contents) {
+      this.coverageData.code = options.contents.split(LINE_ENDINGS);
+    }
+  }
+
+  currentContainer() {
+    return this._containerStack[this._containerStack.length - 1];
+  }
+
+  insertHelper(container, node, hash) {
+    let children = container.body || container.children;
+    let index = children.indexOf(node);
+    let b = this.syntax.builders;
+
+    hash.pairs.push(
+      b.pair('path', b.string(this.moduleName))
+    );
+
+    let helper = b.mustache(
+      b.path('ember-cli-code-coverage-increment'),
+      null,
+      hash
+    );
+    helper.isCoverageHelper = true;
+
+    container._statementsToInsert = container._statementsToInsert || [];
+    container._statementsToInsert.unshift({
+      helper,
+      index
+    });
+  }
+
+  insertStatementHelper(node) {
+    let b = this.syntax.builders;
+
+    let hash = b.hash([
+      b.pair('statement', b.string(this._currentStatement))
+    ]);
+    this.insertHelper(this.currentContainer(), node, hash);
+  }
+
+  insertBranchHelper(container, node, condition) {
+    let b = this.syntax.builders;
+
+    let hash = b.hash([
+      b.pair('branch', b.string(this._currentBranch)),
+      b.pair('condition', b.string(condition))
+    ]);
+
+    this.insertHelper(container, node, hash);
+  }
+
+  processStatementsToInsert(node) {
+    if (node._statementsToInsert) {
+      node._statementsToInsert.forEach((statement) => {
+        let { helper, index } = statement;
+
+        let children = node.children || node.body;
+        children.splice(index, 0, helper);
+      });
+    }
+  }
+
+  handleBlock(node) {
+    // blocks are statements
+    // blocks have contents
+    this.handleStatement(node);
+    this._currentBranch++;
+    this.coverageData.b[this._currentBranch] = 0;
+    this.coverageData.branchMap[this._currentStatement] = {
+      start: { line: node.loc.start.line, column: node.loc.start.column },
+      end: { line: node.loc.end.line, column: node.loc.end.column },
+    };
+
+    if (node.type === 'BlockStatement') {
+      this.insertBranchHelper(node.program, node);
+    }
+  }
+
+  handleStatement(node) {
+    if (node.type === 'TextNode' && node.chars.trim() === '') {
+      return;
+    }
+
+    if (node.isCoverageHelper) { return; }
+
+    this._currentStatement++;
+    this.coverageData.s[this._currentStatement] = 0;
+    this.coverageData.statementMap[this._currentStatement] = {
+      start: { line: node.loc.start.line, column: node.loc.start.column },
+      end: { line: node.loc.end.line, column: node.loc.end.column },
+    };
+
+    this.insertStatementHelper(node);
+  }
+
+  transform(ast) {
+    let handleBlock = {
+      enter: (node) => {
+        this.handleBlock(node);
+        this._containerStack.push(node);
+      },
+      exit: (node) => {
+        this._containerStack.pop();
+        this.processStatementsToInsert(node);
+      }
+    };
+
+    let handleStatement = (node) => this.handleStatement(node);
+
+    let b = this.syntax.builders;
+
+    this.syntax.traverse(ast, {
+      Program: {
+        enter: (node) => {
+          if (!this._topLevelProgram) {
+            this._topLevelProgram = node;
+            this._containerStack = [node];
+          } else {
+            this._containerStack.push(node);
+          }
+        },
+        exit: (node) => {
+          this.processStatementsToInsert(node);
+          if (node === this._topLevelProgram) {
+            let helper = b.mustache(
+              b.path('ember-cli-code-coverage-register'),
+              [
+                b.string(JSON.stringify(this.coverageData))
+              ]
+            );
+            helper.isCoverageHelper = true;
+
+            node.body.unshift(helper);
+          } else {
+            this._containerStack.pop();
+          }
+        },
+      },
+
+      ElementNode: handleBlock,
+      BlockStatement: handleBlock,
+      MustacheStatement: handleStatement,
+      TextNode: handleStatement,
+    });
+
+    return ast;
+  }
+};

--- a/lib/template-instrumenter.js
+++ b/lib/template-instrumenter.js
@@ -1,173 +1,180 @@
 'use strict';
 
 const LINE_ENDINGS = /(?:\r\n?|\n)/;
+const fixPath = require('./coverage-instrumenter').fixPath;
 
-module.exports = class IstanbulInstrumenter {
-  constructor(options) {
+module.exports = function(appName, appRoot, templateExtensions, isAddon) {
+  return class IstanbulInstrumenter {
+    constructor(options) {
 
-    this.options = options;
-    this.moduleName = options.meta && options.meta.moduleName;
+      this.options = options;
 
-    this.coverageData = {
-      path: this.moduleName,
-      s: { },
-      b: { },
-      f: { },
-      fnMap: { },
-      statementMap: { },
-      branchMap: { },
-      code: [ ]
-    };
+      let moduleName = options.meta.moduleName;
+      let relativePath = fixPath(moduleName, appName, appRoot, templateExtensions, isAddon);
 
-    this._currentStatement = 0;
-    this._currentBranch = 0;
+      this.relativePath = relativePath;
 
-    if (options.contents) {
-      this.coverageData.code = options.contents.split(LINE_ENDINGS);
+      this.coverageData = {
+        path: this.relativePath,
+        s: { },
+        b: { },
+        f: { },
+        fnMap: { },
+        statementMap: { },
+        branchMap: { },
+        code: [ ]
+      };
+
+      this._currentStatement = 0;
+      this._currentBranch = 0;
+
+      if (options.contents) {
+        this.coverageData.code = options.contents.split(LINE_ENDINGS);
+      }
     }
-  }
 
-  currentContainer() {
-    return this._containerStack[this._containerStack.length - 1];
-  }
+    currentContainer() {
+      return this._containerStack[this._containerStack.length - 1];
+    }
 
-  insertHelper(container, node, hash) {
-    let children = container.body || container.children;
-    let index = children.indexOf(node);
-    let b = this.syntax.builders;
+    insertHelper(container, node, hash) {
+      let children = container.body || container.children;
+      let index = children.indexOf(node);
+      let b = this.syntax.builders;
 
-    hash.pairs.push(
-      b.pair('path', b.string(this.moduleName))
-    );
+      hash.pairs.push(
+        b.pair('path', b.string(this.relativePath))
+      );
 
-    let helper = b.mustache(
-      b.path('ember-cli-code-coverage-increment'),
-      null,
-      hash
-    );
-    helper.isCoverageHelper = true;
+      let helper = b.mustache(
+        b.path('ember-cli-code-coverage-increment'),
+        null,
+        hash
+      );
+      helper.isCoverageHelper = true;
 
-    container._statementsToInsert = container._statementsToInsert || [];
-    container._statementsToInsert.unshift({
-      helper,
-      index
-    });
-  }
-
-  insertStatementHelper(node) {
-    let b = this.syntax.builders;
-
-    let hash = b.hash([
-      b.pair('statement', b.string(this._currentStatement))
-    ]);
-    this.insertHelper(this.currentContainer(), node, hash);
-  }
-
-  insertBranchHelper(container, node, condition) {
-    let b = this.syntax.builders;
-
-    let hash = b.hash([
-      b.pair('branch', b.string(this._currentBranch)),
-      b.pair('condition', b.string(condition))
-    ]);
-
-    this.insertHelper(container, node, hash);
-  }
-
-  processStatementsToInsert(node) {
-    if (node._statementsToInsert) {
-      node._statementsToInsert.forEach((statement) => {
-        let { helper, index } = statement;
-
-        let children = node.children || node.body;
-        children.splice(index, 0, helper);
+      container._statementsToInsert = container._statementsToInsert || [];
+      container._statementsToInsert.unshift({
+        helper,
+        index
       });
     }
-  }
 
-  handleBlock(node) {
-    // blocks are statements
-    // blocks have contents
-    this.handleStatement(node);
-    this._currentBranch++;
-    this.coverageData.b[this._currentBranch] = 0;
-    this.coverageData.branchMap[this._currentStatement] = {
-      start: { line: node.loc.start.line, column: node.loc.start.column },
-      end: { line: node.loc.end.line, column: node.loc.end.column },
-    };
+    insertStatementHelper(node) {
+      let b = this.syntax.builders;
 
-    if (node.type === 'BlockStatement') {
-      this.insertBranchHelper(node.program, node);
-    }
-  }
-
-  handleStatement(node) {
-    if (node.type === 'TextNode' && node.chars.trim() === '') {
-      return;
+      let hash = b.hash([
+        b.pair('statement', b.string(this._currentStatement))
+      ]);
+      this.insertHelper(this.currentContainer(), node, hash);
     }
 
-    if (node.isCoverageHelper) { return; }
+    insertBranchHelper(container, node, condition) {
+      let b = this.syntax.builders;
 
-    this._currentStatement++;
-    this.coverageData.s[this._currentStatement] = 0;
-    this.coverageData.statementMap[this._currentStatement] = {
-      start: { line: node.loc.start.line, column: node.loc.start.column },
-      end: { line: node.loc.end.line, column: node.loc.end.column },
-    };
+      let hash = b.hash([
+        b.pair('branch', b.string(this._currentBranch)),
+        b.pair('condition', b.string(condition))
+      ]);
 
-    this.insertStatementHelper(node);
-  }
+      this.insertHelper(container, node, hash);
+    }
 
-  transform(ast) {
-    let handleBlock = {
-      enter: (node) => {
-        this.handleBlock(node);
-        this._containerStack.push(node);
-      },
-      exit: (node) => {
-        this._containerStack.pop();
-        this.processStatementsToInsert(node);
+    processStatementsToInsert(node) {
+      if (node._statementsToInsert) {
+        node._statementsToInsert.forEach((statement) => {
+          let { helper, index } = statement;
+
+          let children = node.children || node.body;
+          children.splice(index, 0, helper);
+        });
       }
-    };
+    }
 
-    let handleStatement = (node) => this.handleStatement(node);
+    handleBlock(node) {
+      // blocks are statements
+      // blocks have contents
+      this.handleStatement(node);
+      this._currentBranch++;
+      this.coverageData.b[this._currentBranch] = 0;
+      this.coverageData.branchMap[this._currentStatement] = {
+        start: { line: node.loc.start.line, column: node.loc.start.column },
+        end: { line: node.loc.end.line, column: node.loc.end.column },
+      };
 
-    let b = this.syntax.builders;
+      if (node.type === 'BlockStatement') {
+        this.insertBranchHelper(node.program, node);
+      }
+    }
 
-    this.syntax.traverse(ast, {
-      Program: {
+    handleStatement(node) {
+      if (node.type === 'TextNode' && node.chars.trim() === '') {
+        return;
+      }
+
+      if (node.isCoverageHelper) { return; }
+
+      this._currentStatement++;
+      this.coverageData.s[this._currentStatement] = 0;
+      this.coverageData.statementMap[this._currentStatement] = {
+        start: { line: node.loc.start.line, column: node.loc.start.column },
+        end: { line: node.loc.end.line, column: node.loc.end.column },
+      };
+
+      this.insertStatementHelper(node);
+    }
+
+    transform(ast) {
+      let handleBlock = {
         enter: (node) => {
-          if (!this._topLevelProgram) {
-            this._topLevelProgram = node;
-            this._containerStack = [node];
-          } else {
-            this._containerStack.push(node);
-          }
+          this.handleBlock(node);
+          this._containerStack.push(node);
         },
         exit: (node) => {
+          this._containerStack.pop();
           this.processStatementsToInsert(node);
-          if (node === this._topLevelProgram) {
-            let helper = b.mustache(
-              b.path('ember-cli-code-coverage-register'),
-              [
-                b.string(JSON.stringify(this.coverageData))
-              ]
-            );
-            helper.isCoverageHelper = true;
+        }
+      };
 
-            node.body.unshift(helper);
-          } else {
-            this._containerStack.pop();
-          }
+      let handleStatement = (node) => this.handleStatement(node);
+
+      let b = this.syntax.builders;
+
+      this.syntax.traverse(ast, {
+        Program: {
+          enter: (node) => {
+            if (!this._topLevelProgram) {
+              this._topLevelProgram = node;
+              this._containerStack = [node];
+            } else {
+              this._containerStack.push(node);
+            }
+          },
+          exit: (node) => {
+            this.processStatementsToInsert(node);
+            if (node === this._topLevelProgram) {
+              let helper = b.mustache(
+                b.path('ember-cli-code-coverage-register'),
+                [
+                  b.string(JSON.stringify(this.coverageData))
+                ]
+              );
+              helper.isCoverageHelper = true;
+
+              node.body.unshift(helper);
+            } else {
+              this._containerStack.pop();
+            }
+          },
         },
-      },
 
-      ElementNode: handleBlock,
-      BlockStatement: handleBlock,
-      MustacheStatement: handleStatement,
-      TextNode: handleStatement,
-    });
+        ElementNode: handleBlock,
+        BlockStatement: handleBlock,
+        MustacheStatement: handleStatement,
+        TextNode: handleStatement,
+      });
 
-    return ast;
-  }
+      return ast;
+    }
+  };
 };

--- a/tests/unit/helpers/ember-cli-code-coverage-increment-test.js
+++ b/tests/unit/helpers/ember-cli-code-coverage-increment-test.js
@@ -1,0 +1,61 @@
+import { emberCliCodeCoverageIncrement } from 'dummy/helpers/ember-cli-code-coverage-increment';
+import { module, test } from 'qunit';
+
+const ORIGINAL_COVERAGE = window.__coverage__;
+
+function registerFile(path) {
+  window.__coverage__[path] = {
+    "path": path,
+    "s": {
+      "1": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "5": 0,
+      "6": 0
+    },
+    "b": {
+      "1": [0, 0],
+      "2": [0, 0]
+    },
+    "f": { },
+    "fnMap": { },
+    "statementMap": {
+      // not needed for testing
+    },
+    "branchMap": {
+      // not needed for testing
+    },
+    "code": [
+      // not needed for testing
+    ]
+  };
+}
+
+module('Unit | Helper | ember cli code coverage increment', {
+  beforeEach() {
+    window.__coverage__ = {};
+  },
+
+  afterEach() {
+    window.__coverage__ = ORIGINAL_COVERAGE;
+  }
+});
+
+test('it increments the given statement', function(assert) {
+  let path = 'app/templates/foo';
+  registerFile(path);
+
+  emberCliCodeCoverageIncrement([], { path, statement: "1" });
+
+  assert.equal(window.__coverage__[path].s["1"], 1, 'statement was incremented');
+});
+
+test('it increments the given branch', function(assert) {
+  let path = 'app/templates/foo';
+  registerFile(path);
+
+  emberCliCodeCoverageIncrement([], { path, branch: '1', condition: '0' });
+
+  assert.equal(window.__coverage__[path].b[1][0], 1, 'branch was incremented');
+});

--- a/tests/unit/helpers/ember-cli-code-coverage-register-test.js
+++ b/tests/unit/helpers/ember-cli-code-coverage-register-test.js
@@ -1,0 +1,41 @@
+import { emberCliCodeCoverageRegister } from 'dummy/helpers/ember-cli-code-coverage-register';
+import { module, test } from 'qunit';
+
+const ORIGINAL_COVERAGE = window.__coverage__;
+
+module('Unit | Helper | ember cli code coverage register', {
+  beforeEach() {
+    window.__coverage__ = {};
+    this.fileData = {
+      "path": 'app/templates/foo',
+      "s": {
+        "1": 0,
+        "2": 0
+      },
+      "b": {
+        "1": [0, 0],
+        "2": [0, 0]
+      },
+      "f": { },
+      "fnMap": { },
+      "statementMap": {},
+      "branchMap": {},
+      "code": []
+    };
+  },
+
+  afterEach() {
+    window.__coverage__ = ORIGINAL_COVERAGE;
+  }
+});
+
+// Replace this with your real tests.
+test('registers the given JSON data for the path', function(assert) {
+  emberCliCodeCoverageRegister([JSON.stringify(this.fileData)]);
+
+  assert.deepEqual(
+    window.__coverage__[this.fileData.path],
+    this.fileData,
+    'registered matches'
+  );
+});


### PR DESCRIPTION
This PR adds support for instrumentation of templates roughly the same as JS instrumentation (using a custom set of helpers and a template AST transform to instrument templates).

There are still some issues with this approach that we need to vet/review.

- [ ] Need more testing with "real world" templates.
- [ ] Add logic in `treeFor` to prevent app and addon tree from being emitted unless `COVERAGE=true`.
- [ ] Figure out how to handle instrumentation of usages of `htmlbars-inline-precompiler`.
- [ ] Fix issues with istanbul parsing coverage data.

Paired on this with @rondale-sc.