### PR TITLE
Resolve addon file paths correctly in CLI >= 2.12

### DIFF
--- a/lib/coverage-instrumenter.js
+++ b/lib/coverage-instrumenter.js
@@ -38,10 +38,10 @@ function fixPath(relativePath, name, root, templateExtensions, isAddon) {
       );
     }
 
-    // Handle addons renaming of modules/my-addon
-    if (relativePath.startsWith('modules/' + name)) {
-      var regex = new RegExp('^modules/' + name);
-      relativePath = relativePath.replace(regex, 'addon');
+    // Handle addons renaming of modules/my-addon or my-addon (depending on ember-cli version)
+    var regex = new RegExp('^(modules/)?' + name + '/');
+    if (regex.test(relativePath)) {
+      relativePath = relativePath.replace(regex, 'addon/');
       return (
         getPathForRealFile(relativePath, root, templateExtensions) ||
         relativePath


### PR DESCRIPTION
Starting in (I believe) ember-cli@2.12, addon files stopped being nested under `modules/`, which means the path correction logic here wasn't working properly for them.

If you have thoughts on the best way to test this change, I'd welcome them 🙂 