### PR TITLE
Use the parent registry for determining JS extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,10 +43,11 @@ module.exports = {
 
   // Ember Methods
 
-  included: function() {
+  included: function(appOrAddon) {
     this._super.included.apply(this, arguments);
 
     this.fileLookup = {};
+    this.parentRegistry = appOrAddon.registry;
 
     if (!this._registeredWithBabel && this._isCoverageEnabled()) {
       let checker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
@@ -201,7 +202,7 @@ module.exports = {
   _getIncludesForDir: function(dir, prefix) {
     if (fs.existsSync(dir)) {
       let dirname = path.relative(this.project.root, dir);
-      let globs = this.registry.extensionsForType('js').map((extension) => `**/*.${extension}`);
+      let globs = this.parentRegistry.extensionsForType('js').map((extension) => `**/*.${extension}`);
 
       return walkSync(dir, { directories: false, globs }).map(file => {
         let module = prefix + '/' + file.replace(EXT_RE, '.js');

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -11,9 +11,9 @@ describe('index.js', function() {
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
 
-    Index.parent = Index.project = Index.app = Index.IstanbulPlugin = Index.registry = null;
+    Index.parent = Index.project = Index.app = Index.IstanbulPlugin = Index.parentRegistry = null;
     sandbox.stub(Index, 'fileLookup').value({});
-    sandbox.stub(Index, 'registry').value({
+    sandbox.stub(Index, 'parentRegistry').value({
       extensionsForType: function() {
         return ['js'];
       }


### PR DESCRIPTION
In combination with typed-ember/ember-cli-typescript#144, this should enable coverage reporting for TypeScript files. (Previously we were checking this addon's _own_ preprocessor registry, which would never contain any additional extensions)