### PR TITLE
Filter out in-repo addons that could not be found

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,6 +270,6 @@ module.exports = {
       });
     }
 
-    return this._inRepoAddons;
+    return this._inRepoAddons.filter(Boolean);
   }
 };


### PR DESCRIPTION
`ember-cli@^3.2.0` includes https://github.com/ember-cli/ember-cli/pull/7857, which filters out [blacklisted](https://ember-cli.com/managing-dependencies#whitelisting-and-blacklisting-assets) addons. Therefore, when an in-repo addon is blacklisted, even though its path is listed in package.json, `project.findAddonByName()` will not find it. This results in an error when running `COVERAGE=true ember test` because `ember-cli-code-coverage` assumes all in-repo addons listed in the host app's package.json will be found. This PR adds a truthy filter to remove not-found in-repo addons.