### PR TITLE
fix: handle babel 7 absolute paths

### DIFF
--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -18,9 +18,16 @@ function fixFilePaths(coverageData, fileLookup) {
   return coverageData;
 }
 
-function writeCoverage(coverage, fileLookup, map) {
+function writeCoverage(coverage, fileLookup, root, map) {
+  // Convert absolute paths (path to process.cwd + module path) to relative (module) paths, when necessary (babel >6)
+  // eg. /Users/user/apps/my-ember-app/my-ember-app/app.js => my-ember-app/app.js
+  const fixedCoverage = Object.keys(coverage).reduce((memo, filePath) => {
+    const modulePath = path.relative(root, filePath);
+    memo[modulePath] = Object.assign({}, coverage[filePath], { path: modulePath });
+    return memo;
+  }, {});
   Object.keys(fileLookup).forEach(filename => {
-    let fileCoverage = coverage[filename] || istanbul.libCoverage.createFileCoverage(filename).data;
+    let fileCoverage = fixedCoverage[filename] || istanbul.libCoverage.createFileCoverage(filename).data;
     map.addFileCoverage(fixFilePaths(fileCoverage, fileLookup));
   });
 }
@@ -45,7 +52,7 @@ function reportCoverage(map, root, configPath) {
 }
 
 function coverageHandler(map, options, req, res) {
-  writeCoverage(req.body, options.fileLookup, map);
+  writeCoverage(req.body, options.fileLookup, options.root, map);
   reportCoverage(map, options.root, options.configPath);
   res.send(map.getCoverageSummary());
 }

--- a/test/integration/app-coverage-test.js
+++ b/test/integration/app-coverage-test.js
@@ -25,6 +25,7 @@ describe('app coverage generation', function() {
     }).then(() => {
       app.editPackageJSON(pkg => {
         pkg.devDependencies['ember-exam'] = '1.0.0';
+        pkg.devDependencies['ember-cli-babel'] = '^7.1.0';
         // Temporarily remove the addon before install to work around https://github.com/tomdale/ember-cli-addon-tests/issues/176
         delete pkg.devDependencies['ember-cli-code-coverage'];
       });


### PR DESCRIPTION
Updated `app-coverage-test.js` to test with babel 7 (in-repo-addon and in-repo-engine tests still use babel 6)

fixes #189 