### PR TITLE
fix build issues

### DIFF
--- a/test/integration/app-coverage-test.js
+++ b/test/integration/app-coverage-test.js
@@ -21,7 +21,8 @@ describe('app coverage generation', function() {
   beforeEach(function() {
     app = new AddonTestApp();
     return app.create('my-app', {
-      emberVersion: '3.4.0'
+      emberVersion: '3.4.0',
+      skipNpm: true,
     }).then(() => {
       app.editPackageJSON(pkg => {
         pkg.devDependencies['ember-exam'] = '1.0.0';


### PR DESCRIPTION
I noticed that the first npm install that ember-addon-tests was doing was messing up the node_modules directory since [build #433](https://travis-ci.org/kategengler/ember-cli-code-coverage/jobs/449549515), not sure why (the npm version hadn't changed) - I can only assume that, since we're not using a lockfile, one of the downstream dependencies changed and caused an issue. Am hoping that this should resolve it, but without knowing the root cause I can't be sure (should speed up the build a little at least)