### PR TITLE
Default fileLookup to {} instead of null.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function getPlugins(appOrAddon) {
 // Regular expression to extract the file extension from a path.
 const EXT_RE = /\.[^\.]+$/;
 
-let fileLookup = null;
+let fileLookup = {};
 
 module.exports = {
   name: require('./package').name,

--- a/index.js
+++ b/index.js
@@ -31,8 +31,6 @@ function getPlugins(appOrAddon) {
 // Regular expression to extract the file extension from a path.
 const EXT_RE = /\.[^\.]+$/;
 
-let fileLookup = {};
-
 module.exports = {
   name: require('./package').name,
 
@@ -43,11 +41,14 @@ module.exports = {
   fileLookup: null,
 
   // Ember Methods
+  init: function() {
+    this._super.init.apply(this, arguments);
+    this.fileLookup = {};
+  },
 
   included: function(appOrAddon) {
     this._super.included.apply(this, arguments);
 
-    fileLookup = this.fileLookup = {};
     this.parentRegistry = appOrAddon.registry;
 
     if (!this._registeredWithBabel && this._isCoverageEnabled()) {
@@ -104,7 +105,7 @@ module.exports = {
     attachMiddleware.serverMiddleware(startOptions.app, {
       configPath: this.project.configPath(),
       root: this.project.root,
-      fileLookup: fileLookup
+      fileLookup: this.fileLookup
     });
   },
 
@@ -115,7 +116,7 @@ module.exports = {
     const config = {
       configPath: this.project.configPath(),
       root: this.project.root,
-      fileLookup: fileLookup
+      fileLookup: this.fileLookup
     };
     // if we're running `ember test --server` use the `serverMiddleware`.
     if (process.argv.includes('--server') || process.argv.includes('-s')) {


### PR DESCRIPTION
Attempt to fix https://github.com/kategengler/ember-cli-code-coverage/issues/232.
See a detailed description and analysis of the issue in #232.

The idea is to default `fileLookup` to `{}` instead of `null` this way regardless of the fact that `included` will run or not `fileLookup` should always be non-null.

I'm not 100% sure if this is the best fix for this issue. The issue may be elsewhere in the addons system. I'll leave the reviewer(s) weigh in on this.