### PR TITLE
Ensure coverage collection accounts for addons with a custom `moduleName` implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var config = require('./lib/config');
 const walkSync = require('walk-sync');
 const VersionChecker = require('ember-cli-version-checker');
 const concat = require('lodash.concat');
-const MODULE_NAME = 'ember-cli-code-coverage';
 
 function requireBabelPlugin(pluginName) {
   let plugin = require(pluginName);
@@ -36,10 +35,6 @@ let fileLookup = null;
 
 module.exports = {
   name: require('./package').name,
-
-  moduleName() {
-    return MODULE_NAME;
-  },
 
   /**
    * Look up the file path from an ember module path.
@@ -164,9 +159,8 @@ module.exports = {
    * @returns {Array<String>} include paths
    */
   _getIncludesForAddonDirectory: function() {
-    let coveredModule = this._findCoveredModule();
-    if (coveredModule) {
-      const moduleName = coveredModule.moduleName ? coveredModule.moduleName() : coveredModule.name;
+    let moduleName = this._findCoveredModuleName();
+    if (moduleName) {
       const addonDir = path.join(this.project.root, 'addon');
       const addonTestSupportDir = path.join(this.project.root, 'addon-test-support');
       return concat(
@@ -246,9 +240,7 @@ module.exports = {
    */
   _parentName: function() {
     if (this.parent.isEmberCLIAddon()) {
-      const coveredModule = this._findCoveredModule();
-
-      return coveredModule.moduleName ? coveredModule.moduleName() : coveredModule.name;
+      return this._findCoveredModuleName();
     } else {
       return this.parent.name();
     }
@@ -268,14 +260,14 @@ module.exports = {
 
   /**
    * Find the module (if any) that's being covered.
-   * @returns {Module} the module under test
+   * @returns {String} the name of the module under test
    */
-  _findCoveredModule: function() {
-    if (!this._coveredModule) {
-      this._coveredModule = require(this.project.findAddonByName(this.project.pkg.name).root);
+  _findCoveredModuleName: function() {
+    if (!this._coveredModuleName) {
+      this._coveredModuleName = require(this.project.findAddonByName(this.project.pkg.name).root).moduleName()
     }
 
-    return this._coveredModule;
+    return this._coveredModuleName;
   },
 
   /**

--- a/index.js
+++ b/index.js
@@ -162,10 +162,11 @@ module.exports = {
     let addon = this._findCoveredAddon();
     if (addon) {
       const addonDir = path.join(this.project.root, 'addon');
+      const addonName = addon.moduleName ? addon.moduleName() : addon.name;
       const addonTestSupportDir = path.join(this.project.root, 'addon-test-support');
       return concat(
-        this._getIncludesForDir(addonDir, addon.name),
-        this._getIncludesForDir(addonTestSupportDir, `${addon.name}/test-support`)
+        this._getIncludesForDir(addonDir, addonName),
+        this._getIncludesForDir(addonTestSupportDir, `${addonName}/test-support`)
       );
     }
   },

--- a/index.js
+++ b/index.js
@@ -159,13 +159,13 @@ module.exports = {
    * @returns {Array<String>} include paths
    */
   _getIncludesForAddonDirectory: function() {
-    let addon = this._findCoveredAddon();
-    if (addon) {
+    let moduleName = this._findCoveredModuleName();
+    if (moduleName) {
       const addonDir = path.join(this.project.root, 'addon');
       const addonTestSupportDir = path.join(this.project.root, 'addon-test-support');
       return concat(
-        this._getIncludesForDir(addonDir, addon.name),
-        this._getIncludesForDir(addonTestSupportDir, `${addon.name}/test-support`)
+        this._getIncludesForDir(addonDir, moduleName),
+        this._getIncludesForDir(addonTestSupportDir, `${moduleName}/test-support`)
       );
     }
   },
@@ -240,7 +240,7 @@ module.exports = {
    */
   _parentName: function() {
     if (this.parent.isEmberCLIAddon()) {
-      return this._findCoveredAddon().name;
+      return this._findCoveredModuleName();
     } else {
       return this.parent.name();
     }
@@ -256,6 +256,18 @@ module.exports = {
     }
 
     return this._coveredAddon;
+  },
+
+  /**
+   * Find the module (if any) that's being covered.
+   * @returns {String} the name of the module under test
+   */
+  _findCoveredModuleName: function() {
+    if (!this._coveredModuleName) {
+      this._coveredModuleName = require(this.project.findAddonByName(this.project.pkg.name).root).moduleName()
+    }
+
+    return this._coveredModuleName;
   },
 
   /**

--- a/index.js
+++ b/index.js
@@ -159,13 +159,13 @@ module.exports = {
    * @returns {Array<String>} include paths
    */
   _getIncludesForAddonDirectory: function() {
-    let moduleName = this._findCoveredModuleName();
-    if (moduleName) {
+    let addon = this._findCoveredAddon();
+    if (addon) {
       const addonDir = path.join(this.project.root, 'addon');
       const addonTestSupportDir = path.join(this.project.root, 'addon-test-support');
       return concat(
-        this._getIncludesForDir(addonDir, moduleName),
-        this._getIncludesForDir(addonTestSupportDir, `${moduleName}/test-support`)
+        this._getIncludesForDir(addonDir, addon.name),
+        this._getIncludesForDir(addonTestSupportDir, `${addon.name}/test-support`)
       );
     }
   },
@@ -240,7 +240,7 @@ module.exports = {
    */
   _parentName: function() {
     if (this.parent.isEmberCLIAddon()) {
-      return this._findCoveredModuleName();
+      return this._findCoveredAddon().name;
     } else {
       return this.parent.name();
     }
@@ -256,18 +256,6 @@ module.exports = {
     }
 
     return this._coveredAddon;
-  },
-
-  /**
-   * Find the module (if any) that's being covered.
-   * @returns {String} the name of the module under test
-   */
-  _findCoveredModuleName: function() {
-    if (!this._coveredModuleName) {
-      this._coveredModuleName = require(this.project.findAddonByName(this.project.pkg.name).root).moduleName()
-    }
-
-    return this._coveredModuleName;
   },
 
   /**

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -323,7 +323,7 @@ describe('index.js', function() {
     describe('when parent is an addon', function() {
       beforeEach(function() {
         isAddon = true;
-        sandbox.stub(Index, '_findCoveredModule').returns({ moduleName: () => 'some-addon' });
+        sandbox.stub(Index, '_findCoveredAddon').returns({ name: 'some-addon' });
       });
 
       it('returns the addon name', function() {
@@ -351,40 +351,6 @@ describe('index.js', function() {
 
     it('returns the located addon', function() {
       expect(result.name).to.equal('my-addon');
-    });
-  });
-
-  describe('moduleName', function() {
-    var result;
-
-    beforeEach(function() {
-      result = Index.moduleName();
-    });
-
-    it('returns name of module', function() {
-      expect(result).to.equal('ember-cli-code-coverage');
-    });
-  });
-
-  describe('_findCoveredModule', function() {
-    var result;
-
-    beforeEach(function() {
-      sandbox.stub(Index, 'project').value({
-        findAddonByName: sinon.stub().returns({ name: 'my-addon', root: 'ember-cli-code-coverage' }),
-        pkg: {
-          name: '@scope/ember-cli-my-addon'
-        }
-      });
-      result = Index._findCoveredModule();
-    });
-
-    it('looks up the module by the package name', function() {
-      expect(Index.project.findAddonByName.calledWith('@scope/ember-cli-my-addon')).to.be.true;
-    });
-
-    it('returns the located module name', function() {
-      expect(result.name).to.equal('ember-cli-code-coverage');
     });
   });
 
@@ -450,7 +416,6 @@ describe('index.js', function() {
       describe('for an app', function() {
         beforeEach(function() {
           sandbox.stub(Index, '_findCoveredAddon').returns(null);
-          sandbox.stub(Index, '_findCoveredModule').returns(null);
           sandbox.spy(Index, '_getIncludesForDir');
         });
 
@@ -468,7 +433,6 @@ describe('index.js', function() {
 
         beforeEach(function() {
           sandbox.stub(Index, '_findCoveredAddon').returns(addon);
-          sandbox.stub(Index, '_findCoveredModule').returns(addon);
         });
 
         afterEach(function() {

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -426,9 +426,37 @@ describe('index.js', function() {
         });
       });
 
-      describe('for an addon', function() {
+      describe('for an addon without a moduleName method defined', function() {
         let addon = {
           name: 'my-addon'
+        };
+
+        beforeEach(function() {
+          sandbox.stub(Index, '_findCoveredAddon').returns(addon);
+        });
+
+        afterEach(function() {
+          addon = null;
+        });
+
+        it('gets includes for the addon directory', function() {
+          const includes = Index._getIncludesForAddonDirectory();
+          expect(includes).to.deep.equal([
+            'my-addon/utils/my-covered-util.js',
+            'my-addon/utils/my-uncovered-util.js',
+            'my-addon/test-support/uncovered-test-support.js'
+          ]);
+          expect(Index.fileLookup).to.deep.equal({
+            'my-addon/test-support/uncovered-test-support.js': 'addon-test-support/uncovered-test-support.js',
+            'my-addon/utils/my-covered-util.js': 'addon/utils/my-covered-util.js',
+            'my-addon/utils/my-uncovered-util.js': 'addon/utils/my-uncovered-util.js'
+          });
+        });
+      });
+
+      describe('for an addon with a moduleName method defined', function() {
+        let addon = {
+          moduleName: () => 'my-addon'
         };
 
         beforeEach(function() {

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -323,7 +323,7 @@ describe('index.js', function() {
     describe('when parent is an addon', function() {
       beforeEach(function() {
         isAddon = true;
-        sandbox.stub(Index, '_findCoveredAddon').returns({ name: 'some-addon' });
+        sandbox.stub(Index, '_findCoveredModule').returns({ moduleName: () => 'some-addon' });
       });
 
       it('returns the addon name', function() {
@@ -351,6 +351,40 @@ describe('index.js', function() {
 
     it('returns the located addon', function() {
       expect(result.name).to.equal('my-addon');
+    });
+  });
+
+  describe('moduleName', function() {
+    var result;
+
+    beforeEach(function() {
+      result = Index.moduleName();
+    });
+
+    it('returns name of module', function() {
+      expect(result).to.equal('ember-cli-code-coverage');
+    });
+  });
+
+  describe('_findCoveredModule', function() {
+    var result;
+
+    beforeEach(function() {
+      sandbox.stub(Index, 'project').value({
+        findAddonByName: sinon.stub().returns({ name: 'my-addon', root: 'ember-cli-code-coverage' }),
+        pkg: {
+          name: '@scope/ember-cli-my-addon'
+        }
+      });
+      result = Index._findCoveredModule();
+    });
+
+    it('looks up the module by the package name', function() {
+      expect(Index.project.findAddonByName.calledWith('@scope/ember-cli-my-addon')).to.be.true;
+    });
+
+    it('returns the located module name', function() {
+      expect(result.name).to.equal('ember-cli-code-coverage');
     });
   });
 
@@ -416,6 +450,7 @@ describe('index.js', function() {
       describe('for an app', function() {
         beforeEach(function() {
           sandbox.stub(Index, '_findCoveredAddon').returns(null);
+          sandbox.stub(Index, '_findCoveredModule').returns(null);
           sandbox.spy(Index, '_getIncludesForDir');
         });
 
@@ -433,6 +468,7 @@ describe('index.js', function() {
 
         beforeEach(function() {
           sandbox.stub(Index, '_findCoveredAddon').returns(addon);
+          sandbox.stub(Index, '_findCoveredModule').returns(addon);
         });
 
         afterEach(function() {


### PR DESCRIPTION
Invoking covered module name instead of the covered addon's project payload whenever assessing covered addon's name.
When referencing a covered addon, we should ideally use the module to get the module name, as this is the source of truth when designating the addon name. This fixes the issue wherein if there exists any discrepancy between the module and project name, the coverage report ends up being inaccurate.

Fixes #235 