### PR TITLE
test cases fail with --path option in 1.0.0-beta.8 version

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,10 @@ module.exports = {
     if (!this._isCoverageEnabled()) {
       return;
     }
+
+    if (!this.fileLookup) {
+      this.included(this);
+    }
     const config = {
       configPath: this.project.configPath(),
       root: this.project.root,


### PR DESCRIPTION
Fixes #210 
This PR addresses the issue:
`TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at writeCoverage (/.../node_modules/ember-cli-code-coverage/lib/attach-middleware.js:29:10)`

This issue arises when --path option is specified in the command such as `COVERAGE=true ember exam --path='./testOutput' --split=20 --parallel=1`.

This is due to the included hook which is not invoked when --path option is passed.

We are calling the included hook if the fileLookup object is not built. By doing this, we can build the object correctly which in turn will rectify the error.
