### PR TITLE
fix `InvalidStateError` exception

### DIFF
--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -51,7 +51,12 @@
   }
 
   function handleCoverageResponse(xhr, callback) {
-    var data = xhr.response || xhr.responseText;
+    var data = xhr.response;
+
+    // avoid InvalidStateError by incorrectly accessing xhr.responseText property
+    if (!data && (xhr.responseType === '' || xhr.responseType === 'text')) {
+      data = xhr.responseText;
+    }
 
     // PhantomJS doesn't honor `responseType = 'json'`
     if (typeof data === 'string') {


### PR DESCRIPTION
The xhr.responseText property cannot be accessed
unless xhr.responseType is either 'text' or '',
otherwise it throws an error:

Uncaught InvalidStateError: Failed to read the 'responseText' property from 'XMLHttpRequest':
The value is only accessible if the object's 'responseType' is '' or 'text' (was 'json')

This will therefore happen in handleCoverageResponse whenever
a request either rejects or returns falsy.

This commit introduces a check to only read from the 'responseText'
property in a valid circumstance.