### PR TITLE
fix `InvalidStateError` exception

### DIFF
--- a/lib/attach-middleware.js
+++ b/lib/attach-middleware.js
@@ -54,7 +54,7 @@ function reportCoverage(map, root, configPath) {
 function coverageHandler(map, options, req, res) {
   writeCoverage(req.body, options.fileLookup, options.root, map);
   reportCoverage(map, options.root, options.configPath);
-  res.send(map.getCoverageSummary());
+  res.send(map.getCoverageSummary().toJSON());
 }
 
 // Used when app is in dev mode (`ember serve`).

--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -1,7 +1,4 @@
 <script>
-  // Make synchronous requests in phantom to avoid killing the runner before the coverage completes.
-  var REQUEST_ASYNC = !/PhantomJS/.test(window.navigator.userAgent);
-
   function sendCoverage(callback) {
     {%ENTRIES%}.forEach(function(file) {
       try {
@@ -17,21 +14,14 @@
     var request = new XMLHttpRequest();
     request.open('POST', '/write-coverage', REQUEST_ASYNC);
     request.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+    request.responseType = 'json';
     request.send(data);
 
-    if (REQUEST_ASYNC) {
-      request.responseType = 'json';
-      request.onreadystatechange = function() {
-        if (request.readyState === 4) {
-          handleCoverageResponse(this, callback);
-        }
-      };
-    } else {
-      // The request is already done at this point, since it is synchronous
-      if (request.status === 200) {
-        handleCoverageResponse(request, callback);
+    request.onreadystatechange = function() {
+      if (request.readyState === 4) {
+        handleCoverageResponse(this, callback);
       }
-    }
+    };
   }
 
   if (typeof Testem !== "undefined" && Testem.afterTests) {
@@ -51,11 +41,13 @@
   }
 
   function handleCoverageResponse(xhr, callback) {
-    var data = xhr.response || xhr.responseText;
+    var data = xhr.response;
 
-    // PhantomJS doesn't honor `responseType = 'json'`
-    if (typeof data === 'string') {
-      data = JSON.parse(data);
+    // avoid InvalidStateError by incorrectly accessing xhr.responseText property
+    if (!data && (xhr.responseType === '' || xhr.responseType === 'text')) {
+      data = xhr.responseText;
+    } else {
+      throw new Error(`ember-cli-code-coverage: invalid data ${JSON.stringify(data)} received for responseType ${xhr.responseType}`);
     }
 
     if (!data) {


### PR DESCRIPTION
fix `InvalidStateError` exception

This commit fixes #244.

The xhr.responseText property cannot be accessed unless xhr.responseType is either 'text' or '',
otherwise it throws an error:

Uncaught InvalidStateError: Failed to read the 'responseText' property from 'XMLHttpRequest':
The value is only accessible if the object's 'responseType' is '' or 'text' (was 'json')

This will therefore happen in handleCoverageResponse whenever
a request returns falsy. This should never happen, but is occasionally
flaking and producing the above error.

This commit fixes a few likely culprits:
- responseType = `json` was being set after `xhr.send`, which may cause a race condition
  https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/response
- the middleware called res.send with a CoverageMap may receive a non-serializable
  object, since istanbul CoverageMap provides a toJSON method, implying that
  the default method may not be serializable
- removing now-unused PhantomJS code.
- finally, introduces a check to only read from the 'responseText'
property in a valid circumstance, and gives a more meaningful error otherwise.