### PR TITLE
Remove unused babel-plugin-transform-async-to-generator package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/register": "^7.9.0",
     "babel-plugin-istanbul": "^6.0.0",
-    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "body-parser": "^1.19.0",
     "co": "^4.6.0",
     "ember-cli-version-checker": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2303,7 +2303,7 @@ babel-plugin-syntax-trailing-function-commas@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
   integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
 
-babel-plugin-transform-async-to-generator@^6.22.0, babel-plugin-transform-async-to-generator@^6.24.1:
+babel-plugin-transform-async-to-generator@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
   integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=


### PR DESCRIPTION
This was originally added in #115 but #141 fundamentally changed the implementation such that it was not needed.