### PR TITLE
Remove RSVP dependency.

### DIFF
--- a/lib/coverage-merge.js
+++ b/lib/coverage-merge.js
@@ -3,7 +3,6 @@
 var path = require('path');
 var getConfig = require('./config');
 var dir = require('node-dir');
-var Promise = require('rsvp').Promise;
 
 /**
  * Merge together coverage files created when running in multiple threads,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "istanbul-api": "^2.1.6",
     "lodash.concat": "^4.5.0",
     "node-dir": "^0.1.17",
-    "rsvp": "^4.8.5",
     "walk-sync": "^2.1.0"
   },
   "devDependencies": {

--- a/test/integration/app-coverage-test.js
+++ b/test/integration/app-coverage-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs = require('fs-extra');
-var RSVP = require('rsvp');
-var rimraf = RSVP.denodeify(require('rimraf'));
+const util = require('util');
+const rimraf = util.promisify(require('rimraf'));
 var chai = require('chai');
 var expect = chai.expect;
 var chaiFiles = require('chai-files');
@@ -42,10 +42,8 @@ describe('app coverage generation', function() {
     });
   });
 
-  afterEach(function() {
-    return RSVP.all([
-      rimraf(`${app.path}/config/coverage.js`)
-    ]);
+  afterEach(async function() {
+    await rimraf(`${app.path}/config/coverage.js`)
   });
 
   it('runs coverage when env var is set', function() {

--- a/test/integration/app-coverage-typescript-test.js
+++ b/test/integration/app-coverage-typescript-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs = require('fs-extra');
-var RSVP = require('rsvp');
-var rimraf = RSVP.denodeify(require('rimraf'));
+const util = require('util');
+const rimraf = util.promisify(require('rimraf'));
 var chai = require('chai');
 var expect = chai.expect;
 var chaiFiles = require('chai-files');
@@ -43,10 +43,8 @@ describe('app coverage generation', function() {
     });
   });
 
-  afterEach(function() {
-    return RSVP.all([
-      rimraf(`${app.path}/config/coverage.js`)
-    ]);
+  afterEach(async function() {
+    await rimraf(`${app.path}/config/coverage.js`)
   });
 
   it('runs coverage when env var is set', function() {

--- a/test/integration/in-repo-addon-coverage-test.js
+++ b/test/integration/in-repo-addon-coverage-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs = require('fs-extra');
-var RSVP = require('rsvp');
-var rimraf = RSVP.denodeify(require('rimraf'));
+const util = require('util');
+const rimraf = util.promisify(require('rimraf'));
 var chai = require('chai');
 var expect = chai.expect;
 var chaiFiles = require('chai-files');

--- a/test/integration/in-repo-engine-coverage-test.js
+++ b/test/integration/in-repo-engine-coverage-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var fs = require('fs-extra');
-var RSVP = require('rsvp');
-var rimraf = RSVP.denodeify(require('rimraf'));
+const util = require('util');
+var rimraf = util.promisify(require('rimraf'));
 var chai = require('chai');
 var expect = chai.expect;
 var chaiFiles = require('chai-files');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4013,11 +4013,6 @@ clone@^2.0.0, clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
-
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"


### PR DESCRIPTION
Now that we rely on more recent Node versions, we no longer need to use RSVP for promisy things.