### PR TITLE
Ensure coverage build is parallelizable

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,20 +7,6 @@ var config = require('./lib/config');
 const walkSync = require('walk-sync');
 const VersionChecker = require('ember-cli-version-checker');
 
-function requireBabelPlugin(pluginName) {
-  let plugin = require(pluginName);
-
-  plugin = plugin.__esModule ? plugin.default : plugin;
-
-  // adding `baseDir` ensures that broccoli-babel-transpiler does not
-  // issue a warning and opt out of caching
-  let pluginPath = require.resolve(`${pluginName}/package`);
-  let pluginBaseDir = path.dirname(pluginPath);
-  plugin.baseDir = () => pluginBaseDir;
-
-  return plugin;
-}
-
 function getPlugins(appOrAddon) {
   let options = appOrAddon.options = appOrAddon.options || {};
   options.babel = options.babel || {};
@@ -54,7 +40,7 @@ module.exports = {
       let checker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
 
       if (checker.satisfies('>= 6.0.0')) {
-        const IstanbulPlugin = requireBabelPlugin('babel-plugin-istanbul');
+        const IstanbulPlugin = require.resolve('babel-plugin-istanbul');
         const exclude = this._getExcludes();
         const include = this._getIncludes();
 


### PR DESCRIPTION
The code in `requireBabelPlugin` was attempting to ensure that the cache key used by broccoli-babel-transpiler incorporated the `babel-plugin-istanbul` directory (so that the cache would be invalidated if it was modified / reinstalled).

At the time, this was the best we could do, but broccoli-babel-transpiler now properly caches plugins when provided an absolute path (which is what `require.resolve` returns). This _also_ means that consumers using ember-cli-code-coverage will now be able to have Babel parralellization (which is not possible with the prior implementation).