### PR TITLE
Replace `extend` package with `Object.assign`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,6 @@
  * @property {Array<String>} reporters - list of reporters
  */
 
-var extend = require('extend');
 var fs = require('fs');
 var path = require('path');
 
@@ -25,7 +24,7 @@ function config(configPath) {
 
   if (fs.existsSync(configFile)) {
     var projectConfig = require(configFile);
-    return extend({}, defaultConfig, projectConfig);
+    return Object.assign({}, defaultConfig, projectConfig);
   }
 
   return defaultConfig;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-plugin-istanbul": "^6.0.0",
     "body-parser": "^1.19.0",
     "ember-cli-version-checker": "^5.1.1",
-    "extend": "^3.0.2",
     "fs-extra": "^9.0.0",
     "istanbul-api": "^2.1.6",
     "node-dir": "^0.1.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5872,7 +5872,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==


### PR DESCRIPTION
`extend` (when not using the `deep` option) is doing the same shallow merge that `Object.assign` does. Since we weren't using the `deep` argument (first argument would have to be boolean for that behavior), we can replace this usage with `Object.assign`.