### PR TITLE
Fix issue with coverage report.

### DIFF
--- a/lib/templates/test-body-footer.html
+++ b/lib/templates/test-body-footer.html
@@ -12,7 +12,7 @@
     var data = JSON.stringify(coverageData || {});
 
     var request = new XMLHttpRequest();
-    request.open('POST', '/write-coverage', REQUEST_ASYNC);
+    request.open('POST', '/write-coverage');
     request.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
     request.responseType = 'json';
     request.send(data);
@@ -42,13 +42,6 @@
 
   function handleCoverageResponse(xhr, callback) {
     var data = xhr.response;
-
-    // avoid InvalidStateError by incorrectly accessing xhr.responseText property
-    if (!data && (xhr.responseType === '' || xhr.responseType === 'text')) {
-      data = xhr.responseText;
-    } else {
-      throw new Error(`ember-cli-code-coverage: invalid data ${JSON.stringify(data)} received for responseType ${xhr.responseType}`);
-    }
 
     if (!data) {
       return;

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -59,7 +59,7 @@ describe('index.js', function() {
       });
 
       it('includes the project name in the template for test-body-footer', function() {
-        expect(Index.contentFor('test-body-footer')).to.match(/`["some/module", "some/other/module"`]/);
+        expect(Index.contentFor('test-body-footer')).to.include(`["some/module","some/other/module"]`);
       });
     });
   });


### PR DESCRIPTION
Unfortunately, this codepath is not under test and the changes from https://github.com/kategengler/ember-cli-code-coverage/pull/251 left it in an invalid state.

* The REQUEST_ASYNC variable was no longer present, and therefore referencing it threw an error
* The guard around `xhr.responseText` was no longer needed (we only ever get `JSON`, and `xhr.response` is already parsed properly for us)

We ultimately need to refactor to get this coverage reporting under test (plausibly an end-to-end acceptance test that confirms the expected JSON reporter output after running all the tests).