### PR TITLE
Update instructions for Typescript integration to use 1.0.0-beta.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Steps:
 ```js
   {
     devDependencies: {
-      "ember-cli-code-coverage": "^1.0.0-beta.6"
+      "ember-cli-code-coverage": "^1.0.0-beta.9"
     }
   }
 ```


### PR DESCRIPTION
Versions <1.0.0-beta.9 in fact do not provide TS coverage support.