### PR TITLE
Remove unused `_parentName()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,18 +232,6 @@ module.exports = {
   },
 
   /**
-   * Determine the name of the parent app or addon.
-   * @returns {String} the name of the parent
-   */
-  _parentName() {
-    if (this.parent.isEmberCLIAddon()) {
-      return this._findCoveredAddon().name;
-    } else {
-      return this.parent.name();
-    }
-  },
-
-  /**
    * Find the addon (if any) that's being covered.
    * @returns {Addon} the addon under test
    */

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -296,42 +296,6 @@ describe('index.js', function () {
     });
   });
 
-  describe('_parentName', function () {
-    var isAddon;
-
-    beforeEach(function () {
-      sandbox.stub(Index, 'parent').value({
-        name() {
-          return 'parent-app';
-        },
-        isEmberCLIAddon() {
-          return isAddon;
-        },
-      });
-    });
-
-    describe('when parent is an app', function () {
-      beforeEach(function () {
-        isAddon = false;
-      });
-
-      it('returns the app name', function () {
-        expect(Index._parentName()).to.equal('parent-app');
-      });
-    });
-
-    describe('when parent is an addon', function () {
-      beforeEach(function () {
-        isAddon = true;
-        sandbox.stub(Index, '_findCoveredAddon').returns({ name: 'some-addon' });
-      });
-
-      it('returns the addon name', function () {
-        expect(Index._parentName()).to.equal('some-addon');
-      });
-    });
-  });
-
   describe('_findCoveredAddon', function () {
     var result;
 


### PR DESCRIPTION
This method appears to only be used by the tests that test it 🤔 