### PR TITLE
Simplify `_isCoverageEnabled()` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,13 +222,9 @@ module.exports = {
    * @returns {Boolean} whether or not coverage is enabled
    */
   _isCoverageEnabled() {
-    var value = process.env[this._getConfig().coverageEnvVar] || false;
-
-    if (value.toLowerCase) {
-      value = value.toLowerCase();
-    }
-
-    return ['true', true].indexOf(value) !== -1;
+    let envVar = this._getConfig().coverageEnvVar;
+    let value = process.env[envVar] || '';
+    return value.toLowerCase() === 'true';
   },
 
   /**

--- a/test/integration/app-coverage-test.js
+++ b/test/integration/app-coverage-test.js
@@ -55,7 +55,7 @@ describe('app coverage generation', function () {
   it('runs coverage when env var is set', async function () {
     expect(dir(`${app.path}/coverage`)).to.not.exist;
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'test');
     expect(file(`${app.path}/coverage/lcov-report/index.html`)).to.not.be.empty;
@@ -67,7 +67,7 @@ describe('app coverage generation', function () {
   it('does not run coverage when env var is NOT set', async function () {
     expect(dir(`${app.path}/coverage`)).to.not.exist;
 
-    process.env.COVERAGE = false;
+    process.env.COVERAGE = 'false';
 
     await app.run('ember', 'test');
     expect(dir(`${app.path}/coverage`)).to.not.exist;
@@ -76,7 +76,7 @@ describe('app coverage generation', function () {
   it('excludes files when the configuration is set', async function () {
     fs.copySync('tests/dummy/config/coverage-excludes.js', `${app.path}/config/coverage.js`);
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'test');
     expect(file(`${app.path}/coverage/lcov-report/index.html`)).to.not.be.empty;
@@ -88,7 +88,7 @@ describe('app coverage generation', function () {
   it('merges coverage when tests are run in parallel', async function () {
     expect(dir(`${app.path}/coverage`)).to.not.exist;
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'exam', '--split=2', '--parallel=true');
     expect(file(`${app.path}/coverage/lcov-report/index.html`)).to.not.be.empty;
@@ -101,7 +101,7 @@ describe('app coverage generation', function () {
     expect(dir(`${app.path}/coverage`)).to.not.exist;
     fs.copySync('tests/dummy/config/coverage-parallel.js', `${app.path}/config/coverage.js`);
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'exam', '--split=2', '--parallel=true');
     expect(dir(`${app.path}/coverage`)).to.not.exist;
@@ -119,7 +119,7 @@ describe('app coverage generation', function () {
     expect(dir(coverageFolder)).to.not.exist;
     fs.copySync('tests/dummy/config/coverage-nested-folder.js', `${app.path}/config/coverage.js`);
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'exam', '--split=2', '--parallel=true');
     expect(dir(coverageFolder)).to.not.exist;
@@ -134,7 +134,7 @@ describe('app coverage generation', function () {
   it('runs coverage when a module has an import error', async function () {
     expect(dir(`${app.path}/coverage`)).to.not.exist;
     fs.copySync('test/helpers/error-module.js', `${app.path}/app/error-module.js`);
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'test');
     expect(dir(`${app.path}/coverage`)).to.exist;

--- a/test/integration/in-repo-addon-coverage-test.js
+++ b/test/integration/in-repo-addon-coverage-test.js
@@ -55,7 +55,7 @@ describe('in-repo addon coverage generation', function () {
     let addon = await InRepoAddon.generate(app, 'my-in-repo-addon');
     addon.editPackageJSON(pkg => (pkg.dependencies = { 'ember-cli-babel': '*' }));
     expect(dir(`${app.path}/coverage`)).to.not.exist;
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'test');
 

--- a/test/integration/in-repo-engine-coverage-test.js
+++ b/test/integration/in-repo-engine-coverage-test.js
@@ -66,7 +66,7 @@ describe('in-repo engine coverage generation', function () {
 
     expect(dir(`${app.path}/coverage`)).to.not.exist;
 
-    process.env.COVERAGE = true;
+    process.env.COVERAGE = 'true';
 
     await app.run('ember', 'test');
     expect(file(`${app.path}/coverage/lcov-report/index.html`)).to.not.be.empty;

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -215,16 +215,6 @@ describe('index.js', function () {
       });
     });
 
-    describe('when coverage environment variable is true', function () {
-      beforeEach(function () {
-        process.env.COVERAGE = true;
-      });
-
-      it('returns true', function () {
-        expect(Index._isCoverageEnabled()).to.be.true;
-      });
-    });
-
     describe('when coverage environment variable is string true', function () {
       beforeEach(function () {
         process.env.COVERAGE = 'true';
@@ -242,16 +232,6 @@ describe('index.js', function () {
 
       it('returns true', function () {
         expect(Index._isCoverageEnabled()).to.be.true;
-      });
-    });
-
-    describe('when coverage environment variable is false', function () {
-      beforeEach(function () {
-        process.env.COVERAGE = false;
-      });
-
-      it('returns false', function () {
-        expect(Index._isCoverageEnabled()).to.be.false;
       });
     });
 
@@ -278,16 +258,6 @@ describe('index.js', function () {
     describe('when coverage environment variable is undefined', function () {
       beforeEach(function () {
         delete process.env.COVERAGE;
-      });
-
-      it('returns false', function () {
-        expect(Index._isCoverageEnabled()).to.be.false;
-      });
-    });
-
-    describe('when coverage environment variable is null', function () {
-      beforeEach(function () {
-        process.env.COVERAGE = null;
       });
 
       it('returns false', function () {


### PR DESCRIPTION
Environment variables are inherently string-based and can't use boolean values. This commit changes `_isCoverageEnabled()` to only accept the `true` string (case insensitive).

This probably does not need to be considered a breaking change, since from the outside only the string value was available anyway.