### PR TITLE
Fix empty reports when path option to existing build is used

### DIFF
--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -99,7 +99,7 @@ module.exports = {
       return;
     }
 
-    if (!this.fileLookup) {
+    if (Object.keys(this.fileLookup || {}).length === 0) {
       this.included(this);
     }
     const config = {

--- a/test-packages/__snapshots__/my-app-test.js.snap
+++ b/test-packages/__snapshots__/my-app-test.js.snap
@@ -566,6 +566,141 @@ Object {
 }
 `;
 
+exports[`app coverage generation runs coverage when the path option is used 1`] = `
+Object {
+  "app/app.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 4,
+      "pct": 100,
+      "skipped": 0,
+      "total": 4,
+    },
+    "statements": Object {
+      "covered": 4,
+      "pct": 100,
+      "skipped": 0,
+      "total": 4,
+    },
+  },
+  "app/router.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+  },
+  "app/utils/my-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "app/utils/my-uncovered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "total": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+    "lines": Object {
+      "covered": 6,
+      "pct": 66.67,
+      "skipped": 0,
+      "total": 9,
+    },
+    "statements": Object {
+      "covered": 6,
+      "pct": 66.67,
+      "skipped": 0,
+      "total": 9,
+    },
+  },
+}
+`;
+
 exports[`app coverage generation uses nested coverageFolder and parallel configuration and run merge-coverage 1`] = `
 Object {
   "app/app.js": Object {

--- a/test-packages/index-test.js
+++ b/test-packages/index-test.js
@@ -119,11 +119,18 @@ describe('index.js', function () {
     describe('when coverage is enabled', function () {
       beforeEach(function () {
         sandbox.stub(Index, '_isCoverageEnabled').returns(true);
+        sandbox.stub(Index, 'included').value(sinon.spy());
         Index.testemMiddleware(app);
       });
 
       it('adds POST endpoint to app', function () {
         expect(app.post.callCount).toEqual(1);
+      });
+
+      describe('when the fileLookup is empty', function () {
+        it('calls the included function', function () {
+          expect(Index.included.callCount).toEqual(1);
+        });
       });
     });
 

--- a/test-packages/my-app-test.js
+++ b/test-packages/my-app-test.js
@@ -56,6 +56,19 @@ describe('app coverage generation', function () {
     expect(summary).toMatchSnapshot();
   });
 
+  it('runs coverage when the path option is used', async function () {
+    dir(`${BASE_PATH}/coverage`).assertDoesNotExist();
+
+    let env = { COVERAGE: 'true' };
+    await execa('ember', ['build', '--output-path=test-dist'], { cwd: BASE_PATH, env });
+    await execa('ember', ['test', '--path=test-dist'], { cwd: BASE_PATH, env });
+    file(`${BASE_PATH}/coverage/lcov-report/index.html`).assertIsNotEmpty();
+    file(`${BASE_PATH}/coverage/index.html`).assertIsNotEmpty();
+
+    let summary = fs.readJSONSync(`${BASE_PATH}/coverage/coverage-summary.json`);
+    expect(summary).toMatchSnapshot();
+  });
+
   it('merges coverage when tests are run in parallel', async function () {
     dir(`${BASE_PATH}/coverage`).assertDoesNotExist();
 


### PR DESCRIPTION
At the company where I work I was working on speeding up tests by splitting them and running them in parallel. For this I used the `--path` option, after which the coverage wasn't working anymore. I saw [this](https://github.com/kategengler/ember-cli-code-coverage/issues/271) issue, which is the exact problem I ran into. However, the initial fix mentioned there wasn't actually working, so the issue is still there in v1.0.0. Reason is that `!this.fileLookup` returns false for empty objects. After fixing that line, the coverage was working again.

I also added a basic test to make sure it actually works.