### PR TITLE
Fix missing/incorrect file paths in lcov

### DIFF
--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -128,8 +128,8 @@ module.exports = {
    */
   _getIncludes() {
     return [
-      ...this._getIncludesForInRepoAddonDirectories(),
       ...this._getIncludesForAddonDirectory(),
+      ...this._getIncludesForInRepoAddonDirectories(),
       ...this._getIncludesForAppDirectory(),
     ].filter(Boolean);
   },

--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -128,9 +128,9 @@ module.exports = {
    */
   _getIncludes() {
     return [
-      ...this._getIncludesForAppDirectory(),
-      ...this._getIncludesForAddonDirectory(),
       ...this._getIncludesForInRepoAddonDirectories(),
+      ...this._getIncludesForAddonDirectory(),
+      ...this._getIncludesForAppDirectory(),
     ].filter(Boolean);
   },
 
@@ -155,8 +155,8 @@ module.exports = {
       const addonName = addon.moduleName ? addon.moduleName() : addon.name;
       const addonTestSupportDir = path.join(this.project.root, 'addon-test-support');
       return [
-        ...this._getIncludesForDir(addonDir, addonName),
         ...this._getIncludesForDir(addonTestSupportDir, `${addonName}/test-support`),
+        ...this._getIncludesForDir(addonDir, addonName),
       ];
     } else {
       return [];
@@ -180,9 +180,9 @@ module.exports = {
 
       return [
         ...acc,
-        ...this._getIncludesForDir(addonAppDir, this.parent.name()),
-        ...this._getIncludesForDir(addonAddonDir, addon.name),
         ...this._getIncludesForDir(addonAddonTestSupportDir, `${addon.name}/test-support`),
+        ...this._getIncludesForDir(addonAddonDir, addon.name),
+        ...this._getIncludesForDir(addonAppDir, this.parent.name()),
       ];
     }, []);
   },

--- a/test-packages/__snapshots__/in-repo-addon-test.js.snap
+++ b/test-packages/__snapshots__/in-repo-addon-test.js.snap
@@ -54,6 +54,32 @@ Object {
       "total": 3,
     },
   },
+  "app/services/my-service.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
   "app/utils/my-covered-util-app.js": Object {
     "branches": Object {
       "covered": 0,
@@ -130,6 +156,32 @@ Object {
       "pct": 0,
       "skipped": 0,
       "total": 4,
+    },
+  },
+  "lib/my-in-repo-addon/addon/services/my-service.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
     },
   },
   "lib/my-in-repo-addon/addon/utils/my-covered-util.js": Object {
@@ -244,22 +296,22 @@ Object {
       "total": 2,
     },
     "functions": Object {
-      "covered": 2,
-      "pct": 28.57,
+      "covered": 3,
+      "pct": 33.33,
       "skipped": 0,
-      "total": 7,
+      "total": 9,
     },
     "lines": Object {
-      "covered": 7,
-      "pct": 46.67,
+      "covered": 8,
+      "pct": 47.06,
       "skipped": 0,
-      "total": 15,
+      "total": 17,
     },
     "statements": Object {
-      "covered": 7,
-      "pct": 46.67,
+      "covered": 8,
+      "pct": 47.06,
       "skipped": 0,
-      "total": 15,
+      "total": 17,
     },
   },
 }

--- a/test-packages/index-test.js
+++ b/test-packages/index-test.js
@@ -389,9 +389,9 @@ describe('index.js', function () {
         it('gets includes for the addon directory', function () {
           const includes = Index._getIncludesForAddonDirectory();
           expect(includes).toEqual([
+            'my-addon/test-support/uncovered-test-support.js',
             'my-addon/utils/my-covered-util.js',
             'my-addon/utils/my-uncovered-util.js',
-            'my-addon/test-support/uncovered-test-support.js',
           ]);
           expect(Index.fileLookup).toEqual({
             'my-addon/test-support/uncovered-test-support.js':
@@ -418,9 +418,9 @@ describe('index.js', function () {
         it('gets includes for the addon directory', function () {
           const includes = Index._getIncludesForAddonDirectory();
           expect(includes).toEqual([
+            'my-addon/test-support/uncovered-test-support.js',
             'my-addon/utils/my-covered-util.js',
             'my-addon/utils/my-uncovered-util.js',
-            'my-addon/test-support/uncovered-test-support.js',
           ]);
           expect(Index.fileLookup).toEqual({
             'my-addon/test-support/uncovered-test-support.js':
@@ -471,16 +471,21 @@ describe('index.js', function () {
         it('instruments the inrepo addon', function () {
           const includes = Index._getIncludesForInRepoAddonDirectories();
           expect(includes).toEqual([
-            'my-app/utils/my-covered-util.js',
-            'my-app/utils/my-uncovered-util.js',
+            'my-in-repo-addon/test-support/uncovered-test-support.js',
+            'my-in-repo-addon/services/my-service.js',
             'my-in-repo-addon/utils/my-covered-util.js',
             'my-in-repo-addon/utils/my-uncovered-util.js',
-            'my-in-repo-addon/test-support/uncovered-test-support.js',
+            'my-app/services/my-service.js',
+            'my-app/utils/my-covered-util.js',
+            'my-app/utils/my-uncovered-util.js',
+            
           ]);
           expect(Index.fileLookup).toEqual({
+            "my-app/services/my-service.js": "lib/my-in-repo-addon/app/services/my-service.js",
             'my-app/utils/my-covered-util.js': 'lib/my-in-repo-addon/app/utils/my-covered-util.js',
             'my-app/utils/my-uncovered-util.js':
               'lib/my-in-repo-addon/app/utils/my-uncovered-util.js',
+            "my-in-repo-addon/services/my-service.js": "lib/my-in-repo-addon/addon/services/my-service.js",
             'my-in-repo-addon/utils/my-covered-util.js':
               'lib/my-in-repo-addon/addon/utils/my-covered-util.js',
             'my-in-repo-addon/utils/my-uncovered-util.js':
@@ -517,11 +522,11 @@ describe('index.js', function () {
         it('instruments the inrepo addon', function () {
           const includes = Index._getIncludesForInRepoAddonDirectories();
           expect(includes).toEqual([
-            'my-app/utils/my-covered-util.js',
-            'my-app/utils/my-uncovered-util.js',
+            'my-in-repo-addon/test-support/uncovered-test-support.js',
             'my-in-repo-addon/utils/my-covered-util.js',
             'my-in-repo-addon/utils/my-uncovered-util.js',
-            'my-in-repo-addon/test-support/uncovered-test-support.js',
+            'my-app/utils/my-covered-util.js',
+            'my-app/utils/my-uncovered-util.js',
           ]);
           expect(Index.fileLookup).toEqual({
             'my-app/utils/my-covered-util.js':

--- a/test-packages/my-app-with-in-repo-addon/app/services/my-service.js
+++ b/test-packages/my-app-with-in-repo-addon/app/services/my-service.js
@@ -1,0 +1,7 @@
+import MyService from 'my-in-repo-addon/services/my-service';
+
+export default MyService.extend({
+    testFunc() {
+        return true;
+    }
+});

--- a/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/addon/services/my-service.js
+++ b/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/addon/services/my-service.js
@@ -1,0 +1,7 @@
+import Service from '@ember/service';
+
+export default Service.extend({
+    testFunc() {
+        return false;
+    }
+});

--- a/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/services/my-service.js
+++ b/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/services/my-service.js
@@ -1,0 +1,1 @@
+export { default } from 'my-in-repo-addon/services/my-service';

--- a/test-packages/my-app-with-in-repo-addon/tests/unit/services/my-service-test.js
+++ b/test-packages/my-app-with-in-repo-addon/tests/unit/services/my-service-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | my-service', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const service = this.owner.lookup('service:my-service');
+    assert.ok(service);
+  });
+
+  test('testFunc() returns expected value', function(assert) {
+    const service = this.owner.lookup('service:my-service');
+    assert.equal(service.testFunc(), true, 'Expected `testFunc()` to be overwritten by app to return `true`');
+  });
+});


### PR DESCRIPTION
Given a repo with an in-repo-addon that re-exports a module, e.g. service, when the repo has an overriding file of what the in-repo-addon exports, then the overriding file should be included in the lcov file.

E.g., Given the following paths exists in the app
```
app/services/my-service.js
lib/my-in-repo-addon/addon/services/my-service.js
lib/my-in-repo-addon/app/services/my-service.js
```

Expected: lcov file should include the following lines.
```
SF:app/services/my-service.js
SF:lib/my-in-repo-addon/addon/services/my-service.js
```

Actual: lcov file includes the wrong path, such as the following lines.
```
SF:lib/my-in-repo-addon/app/services/my-service.js
SF:lib/my-in-repo-addon/addon/services/my-service.js
```