### PR TITLE
Make sure to fire callback whenever handleCoverageResponse has fired

### DIFF
--- a/packages/ember-cli-code-coverage/lib/templates/test-body-footer.html
+++ b/packages/ember-cli-code-coverage/lib/templates/test-body-footer.html
@@ -43,11 +43,8 @@
   function handleCoverageResponse(xhr, callback) {
     var data = xhr.response;
 
-    if (!data) {
-      return;
-    }
-
-    var results = ['Lines', 'Branches', 'Functions', 'Statements']
+    if (data) {
+      var results = ['Lines', 'Branches', 'Functions', 'Statements']
       .filter(function (name) {
         return name.toLowerCase();
       })
@@ -55,11 +52,12 @@
         return name + ' ' + data[name.toLowerCase()].pct + '%'
       });
 
-    var resultsText = document.createTextNode(results.join(' | '));
-    var element = document.createElement('div');
-    element.style = 'background-color: white; color: black; border: 2px solid black; padding: 1em;position: fixed; left: 15px; bottom: 15px';
-    element.appendChild(resultsText);
-    document.body.appendChild(element);
+      var resultsText = document.createTextNode(results.join(' | '));
+      var element = document.createElement('div');
+      element.style = 'background-color: white; color: black; border: 2px solid black; padding: 1em;position: fixed; left: 15px; bottom: 15px';
+      element.appendChild(resultsText);
+      document.body.appendChild(element);
+    }
 
     if (callback) {
       callback();


### PR DESCRIPTION
Reason:
  on testem, callback will invoke afterTests and it will emit disconnect. There are rare occasions empty data gets into handleCoverageResponse.
Which skips emitting disconnect event and hence testem will invoke processExit and it will eventually time outs no matter what timeout value is.
Invoking callback regardless of data's value will make sure testem to invoke afterTests

cc @rwjblue 