### PR TITLE
Fix no coverage reported for files in app directory of in-repo addons

### DIFF
--- a/test-packages/__snapshots__/custom-path-in-repo-addon-test.js.snap
+++ b/test-packages/__snapshots__/custom-path-in-repo-addon-test.js.snap
@@ -184,6 +184,58 @@ Object {
       "total": 1,
     },
   },
+  "local-lib/addons/my-in-repo-addon/app/utils/my-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
+  "local-lib/addons/my-in-repo-addon/app/utils/my-uncovered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
   "total": Object {
     "branches": Object {
       "covered": 0,

--- a/test-packages/__snapshots__/in-repo-addon-test.js.snap
+++ b/test-packages/__snapshots__/in-repo-addon-test.js.snap
@@ -236,6 +236,84 @@ Object {
       "total": 1,
     },
   },
+  "lib/my-in-repo-addon/app/utils/my-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
+  "lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "lib/my-in-repo-addon/app/utils/my-uncovered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
   "total": Object {
     "branches": Object {
       "covered": 0,
@@ -244,22 +322,22 @@ Object {
       "total": 2,
     },
     "functions": Object {
-      "covered": 3,
-      "pct": 33.33,
+      "covered": 4,
+      "pct": 40,
       "skipped": 0,
-      "total": 9,
+      "total": 10,
     },
     "lines": Object {
-      "covered": 8,
-      "pct": 47.06,
+      "covered": 9,
+      "pct": 50,
       "skipped": 0,
-      "total": 17,
+      "total": 18,
     },
     "statements": Object {
-      "covered": 8,
-      "pct": 47.06,
+      "covered": 9,
+      "pct": 50,
       "skipped": 0,
-      "total": 17,
+      "total": 18,
     },
   },
 }

--- a/test-packages/attach-middleware-test.js
+++ b/test-packages/attach-middleware-test.js
@@ -40,17 +40,18 @@ describe('attach-middleware', () => {
       ['hello', 'lib/hello/addon'],
       ['hello/test-support', 'lib/hello/addon-test-support'],
     ]);
+    let inRepoPaths = ['lib/hello'];
 
-    expect(adjustCoverageKey(root, path.join(root, 'app-namespace/app.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'app-namespace/app.js'), namespaceMappings, inRepoPaths))
       .toEqual('app/app.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'app-namespace/components/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'app-namespace/components/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('app/components/foo.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'hello/components/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'hello/components/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('lib/hello/addon/components/foo.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'hello/test-support/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'hello/test-support/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('lib/hello/addon-test-support/foo.js');
   });
 
@@ -62,17 +63,18 @@ describe('attach-middleware', () => {
       ['hello', 'lib/hello/addon'],
       ['hello/test-support', 'lib/hello/addon-test-support'],
     ]);
+    let inRepoPaths = ['lib/hello'];
 
-    expect(adjustCoverageKey(root, path.join(root, 'addon-namespace/components/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'addon-namespace/components/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('addon/components/foo.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'addon-namespace/test-support/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'addon-namespace/test-support/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('addon-test-support/foo.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'hello/components/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'hello/components/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('lib/hello/addon/components/foo.js');
 
-    expect(adjustCoverageKey(root, path.join(root, 'hello/test-support/foo.js'), namespaceMappings))
+    expect(adjustCoverageKey(root, path.join(root, 'hello/test-support/foo.js'), namespaceMappings, inRepoPaths))
       .toEqual('lib/hello/addon-test-support/foo.js');
   });
 });

--- a/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js
+++ b/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js
@@ -1,0 +1,3 @@
+export default function myInRepoAddonAppCoveredUtil() {
+  return true;
+}

--- a/test-packages/my-app-with-in-repo-addon/tests/unit/utils/my-in-repo-addon-app-covered-util-test.js
+++ b/test-packages/my-app-with-in-repo-addon/tests/unit/utils/my-in-repo-addon-app-covered-util-test.js
@@ -1,0 +1,10 @@
+import myInRepoAddonAppCoveredUtil from 'my-app-with-in-repo-addon/utils/my-in-repo-addon-app-covered-util';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | my in repo addon app covered util');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = myInRepoAddonAppCoveredUtil();
+  assert.ok(result);
+});


### PR DESCRIPTION
In this PR I first added a failing test to confirm [this issue](https://github.com/kategengler/ember-cli-code-coverage/issues/341). Then I tried diving into the code to see if I could fix it, which I eventually could. I've tested this with our codebase and all our files showed up correctly again :raised_hands: I'm not too sure if this is the right way to fix it, so I'm open for suggestions.

~First I generated the changes in the snapshot by moving the added util to `addon` and re-exporting it in `app`. Then I moved it back from `addon` to `app` and manually adapted the snapshot. So, I expect this test to pass when the issue is fixed, and otherwise it will probably require a little tweak to get it working~. Edit: it did require a small tweak, as I was missing the two re-exports that had no effect on the coverage in the test. The rest of the initial failing test was working as I expected it to.

If I understand correctly, the coverage is reported for files like `app-namespace/components/...`, `in-repo-addon/components/...`, paths that are then converted into `app/components` and `lib/in-repo-addon/addon/components` respectively (assuming that the in-repo addon is in `lib/in-repo-addon`). For the `app` files in those addons though, the initial path is also `app-namespace/components/...`, so then there is no trivial mapping to the addon's `app` directory possible. In the end I got it working by checking if the file exists in the app-namespace's `app`, and if not, it has to come from an addon. It can still come from another addon though, so then I checked per in-repo addon whether the file exists there or not. If it does exist, we know that the path should be changed to the addon's path.

This approach does work for our codebase and in the tests and I also found something else it covers now as well. In the `in-repo-addon` test the `my-app-with-in-repo-addon/lib/my-in-repo-addon/app/services/my-service.js` file isn't covered because of `app/services/my-service.js`, so that's a nice bonus I'd say :).