### PR TITLE
Add test for files in app directory of in-repo addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,10 +211,12 @@ be relative to your project root.
 const app = new EmberApp(defaults, {
   'ember-cli-code-coverage': {
     modifyAssetLocation(root, relativePath) {
-      // here is an example of saying that `component/foo.js` actually
-      // lives in `lib/common/app/foo.js` on disk.
-      if (fs.existsSync(path.join(root, 'lib/inrepo/app', relativePath))) {
-        return path.join('lib/common/app', relativePath);
+      let appPath = relativePath.replace('my-project-name', 'app');
+
+      // here is an example of saying that `app/components/foo.js` actually
+      // lives in `lib/inrepo/app/components/foo.js` on disk.
+      if (fs.existsSync(path.join(root, 'lib/inrepo', appPath))) {
+        return path.join('lib/inrepo', appPath);
       }
 
       return false;

--- a/test-packages/__snapshots__/in-repo-addon-test.js.snap
+++ b/test-packages/__snapshots__/in-repo-addon-test.js.snap
@@ -236,6 +236,84 @@ Object {
       "total": 1,
     },
   },
+  "lib/my-in-repo-addon/app/utils/my-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
+  "lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "lib/my-in-repo-addon/app/utils/my-uncovered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 0,
+    },
+  },
   "total": Object {
     "branches": Object {
       "covered": 0,
@@ -244,22 +322,22 @@ Object {
       "total": 2,
     },
     "functions": Object {
-      "covered": 3,
-      "pct": 33.33,
+      "covered": 4,
+      "pct": 40,
       "skipped": 0,
-      "total": 9,
+      "total": 10,
     },
     "lines": Object {
-      "covered": 8,
-      "pct": 47.06,
+      "covered": 9,
+      "pct": 50,
       "skipped": 0,
-      "total": 17,
+      "total": 18,
     },
     "statements": Object {
-      "covered": 8,
-      "pct": 47.06,
+      "covered": 9,
+      "pct": 50,
       "skipped": 0,
-      "total": 17,
+      "total": 18,
     },
   },
 }

--- a/test-packages/my-app-with-in-repo-addon/ember-cli-build.js
+++ b/test-packages/my-app-with-in-repo-addon/ember-cli-build.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const fs = require('fs');
+const path = require('path');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
@@ -9,6 +11,17 @@ module.exports = function(defaults) {
         ...require('ember-cli-code-coverage').buildBabelPlugin(),
       ],
     },
+    'ember-cli-code-coverage': {
+      modifyAssetLocation(root, relativePath) {
+        let appPath = relativePath.replace('my-app-with-in-repo-addon', 'app');
+
+        if (!fs.existsSync(appPath) && fs.existsSync(path.join(root, 'lib/my-in-repo-addon', appPath))) {
+          return path.join('lib/my-in-repo-addon', appPath);
+        }
+
+        return false;
+      }
+    }
   });
 
   // Use `app.import` to add additional libraries to the generated

--- a/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js
+++ b/test-packages/my-app-with-in-repo-addon/lib/my-in-repo-addon/app/utils/my-in-repo-addon-app-covered-util.js
@@ -1,0 +1,3 @@
+export default function myInRepoAddonAppCoveredUtil() {
+  return true;
+}

--- a/test-packages/my-app-with-in-repo-addon/tests/unit/utils/my-in-repo-addon-app-covered-util-test.js
+++ b/test-packages/my-app-with-in-repo-addon/tests/unit/utils/my-in-repo-addon-app-covered-util-test.js
@@ -1,0 +1,10 @@
+import myInRepoAddonAppCoveredUtil from 'my-app-with-in-repo-addon/utils/my-in-repo-addon-app-covered-util';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | my in repo addon app covered util');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = myInRepoAddonAppCoveredUtil();
+  assert.ok(result);
+});


### PR DESCRIPTION
This PR adds a test to confirm `modifyAssetLocation` works as expected when not using the `--path` option. I cherry-picked this from https://github.com/kategengler/ember-cli-code-coverage/pull/342 and used `modifyAssetLocation` to make the tests pass. The example in the readme wasn't sufficient though, as the `relativePath` doesn't start with `app`, but with the project name (as this is not replaced by the `namespaceMapping` yet at this point), so I adjusted the readme to make this more clear.