### PR TITLE
Add support for configurable write path - /write-coverage

### DIFF
--- a/packages/ember-cli-code-coverage/addon-test-support/index.js
+++ b/packages/ember-cli-code-coverage/addon-test-support/index.js
@@ -64,7 +64,7 @@ export function forceModulesToBeLoaded(filterFunction) {
   });
 }
 
-export async function sendCoverage(callback) {
+export async function sendCoverage(callback, writePath = '/write-coverage') {
   let coverageData = window.__coverage__; //eslint-disable-line no-undef
 
   if (coverageData === undefined) {
@@ -77,7 +77,7 @@ export async function sendCoverage(callback) {
 
   let body = JSON.stringify(coverageData || {});
 
-  let response = await fetch('/write-coverage', {
+  let response = await fetch(writePath, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -9,8 +9,6 @@ const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs-extra');
 
-const WRITE_COVERAGE = '/write-coverage';
-
 function logError(err, req, res, next) {
   console.error(err.stack);
   next(err);
@@ -183,8 +181,10 @@ function coverageHandler(map, options, req, res) {
 // Used when app is in dev mode (`ember serve`).
 // Creates a new coverage map on every request.
 function serverMiddleware(app, options) {
+  let { writePath } = getConfig(options.configPath);
+
   app.post(
-    WRITE_COVERAGE,
+    writePath,
     bodyParser,
     (req, res) => {
       let map = libCoverage.createCoverageMap();
@@ -198,10 +198,11 @@ function serverMiddleware(app, options) {
 // Used when app is in ci mode (`ember test`).
 // Collects the coverage on each request and merges it into the coverage map.
 function testMiddleware(app, options) {
+  let { writePath } = getConfig(options.configPath);
   let map = libCoverage.createCoverageMap();
 
   app.post(
-    WRITE_COVERAGE,
+    writePath,
     bodyParser,
     (req, res) => {
       coverageHandler(map, options, req, res);

--- a/packages/ember-cli-code-coverage/lib/config.js
+++ b/packages/ember-cli-code-coverage/lib/config.js
@@ -40,6 +40,7 @@ function getDefaultConfig() {
     coverageFolder: 'coverage',
     excludes: ['*/mirage/**/*'],
     reporters: ['html', 'lcov'],
+    writePath: '/write-coverage',
   };
 }
 

--- a/test-packages/__snapshots__/custom-write-path-test.js.snap
+++ b/test-packages/__snapshots__/custom-write-path-test.js.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`app coverage generation with custom writePath runs coverage with custom writePath set 1`] = `
+Object {
+  "app/app.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "lines": Object {
+      "covered": 4,
+      "pct": 100,
+      "skipped": 0,
+      "total": 4,
+    },
+    "statements": Object {
+      "covered": 4,
+      "pct": 100,
+      "skipped": 0,
+      "total": 4,
+    },
+  },
+  "app/router.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+  },
+  "app/utils/my-covered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 1,
+      "pct": 100,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "app/utils/my-uncovered-util.js": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "lines": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+    "statements": Object {
+      "covered": 0,
+      "pct": 0,
+      "skipped": 0,
+      "total": 1,
+    },
+  },
+  "total": Object {
+    "branches": Object {
+      "covered": 0,
+      "pct": 100,
+      "skipped": 0,
+      "total": 0,
+    },
+    "functions": Object {
+      "covered": 1,
+      "pct": 33.33,
+      "skipped": 0,
+      "total": 3,
+    },
+    "lines": Object {
+      "covered": 6,
+      "pct": 66.67,
+      "skipped": 0,
+      "total": 9,
+    },
+    "statements": Object {
+      "covered": 6,
+      "pct": 66.67,
+      "skipped": 0,
+      "total": 9,
+    },
+  },
+}
+`;

--- a/test-packages/custom-write-path-test.js
+++ b/test-packages/custom-write-path-test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const fs = require('fs-extra');
+const util = require('util');
+const rimraf = util.promisify(require('rimraf'));
+const { dir, file } = require('chai-files');
+const path = require('path');
+const execa = require('execa');
+
+const BASE_PATH = path.join(__dirname, 'my-app-with-custom-write-path');
+
+describe('app coverage generation with custom writePath', function () {
+  jest.setTimeout(10000000);
+
+  beforeEach(async function () {
+    await rimraf(`${BASE_PATH}/coverage*`);
+    await execa('git', ['clean', '-f', 'my-app-with-custom-write-path'], { cwd: __dirname });
+    await execa('git', ['restore', 'my-app-with-custom-write-path'], { cwd: __dirname });
+  });
+
+  afterEach(async function () {
+    await rimraf(`${BASE_PATH}/coverage*`);
+    await execa('git', ['clean', '-f', 'my-app-with-custom-write-path'], { cwd: __dirname });
+    await execa('git', ['restore', 'my-app-with-custom-write-path'], { cwd: __dirname });
+  });
+
+  it('runs coverage with custom writePath set', async function () {
+    dir(`${BASE_PATH}/coverage`).assertDoesNotExist();
+
+    let env = { COVERAGE: 'true' };
+    await execa('ember', ['test'], { cwd: BASE_PATH, env });
+    file(`${BASE_PATH}/coverage/lcov-report/index.html`).assertIsNotEmpty();
+    file(`${BASE_PATH}/coverage/index.html`).assertIsNotEmpty();
+
+    let summary = fs.readJSONSync(`${BASE_PATH}/coverage/coverage-summary.json`);
+    expect(summary).toMatchSnapshot();
+  });
+});

--- a/test-packages/my-app-with-custom-write-path/-error-module.js
+++ b/test-packages/my-app-with-custom-write-path/-error-module.js
@@ -1,0 +1,5 @@
+// This exists to confirm that modules that throw errors during
+// eval, do not fail the build
+//
+// See https://github.com/kategengler/ember-cli-code-coverage/issues/63 for details.
+throw new Error('Error thrown on import!');

--- a/test-packages/my-app-with-custom-write-path/.editorconfig
+++ b/test-packages/my-app-with-custom-write-path/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+insert_final_newline = false
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/test-packages/my-app-with-custom-write-path/.ember-cli
+++ b/test-packages/my-app-with-custom-write-path/.ember-cli
@@ -1,0 +1,9 @@
+{
+  /**
+    Ember CLI sends analytics information by default. The data is completely
+    anonymous, but there are times when you might want to disable this behavior.
+
+    Setting `disableAnalytics` to true will prevent any data from being sent.
+  */
+  "disableAnalytics": false
+}

--- a/test-packages/my-app-with-custom-write-path/.eslintignore
+++ b/test-packages/my-app-with-custom-write-path/.eslintignore
@@ -1,0 +1,20 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/coverage/
+!.*
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try

--- a/test-packages/my-app-with-custom-write-path/.eslintrc.js
+++ b/test-packages/my-app-with-custom-write-path/.eslintrc.js
@@ -1,0 +1,56 @@
+'use strict';
+
+module.exports = {
+  root: true,
+  parser: 'babel-eslint',
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      legacyDecorators: true
+    }
+  },
+  plugins: [
+    'ember'
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended'
+  ],
+  env: {
+    browser: true
+  },
+  rules: {
+    'ember/no-jquery': 'error'
+  },
+  overrides: [
+    // node files
+    {
+      files: [
+        '.eslintrc.js',
+        '.template-lintrc.js',
+        'ember-cli-build.js',
+        'testem.js',
+        'blueprints/*/index.js',
+        'config/**/*.js',
+        'lib/*/index.js',
+        'server/**/*.js'
+      ],
+      parserOptions: {
+        sourceType: 'script'
+      },
+      env: {
+        browser: false,
+        node: true
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+
+        // this can be removed once the following is fixed
+        // https://github.com/mysticatea/eslint-plugin-node/issues/77
+        'node/no-unpublished-require': 'off'
+      })
+    }
+  ]
+};

--- a/test-packages/my-app-with-custom-write-path/.gitignore
+++ b/test-packages/my-app-with-custom-write-path/.gitignore
@@ -1,0 +1,25 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+/node_modules/
+
+# misc
+/.env*
+/.pnp*
+/.sass-cache
+/connect.lock
+/coverage*/
+/libpeerconnection.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try

--- a/test-packages/my-app-with-custom-write-path/.template-lintrc.js
+++ b/test-packages/my-app-with-custom-write-path/.template-lintrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: 'octane'
+};

--- a/test-packages/my-app-with-custom-write-path/.travis.yml
+++ b/test-packages/my-app-with-custom-write-path/.travis.yml
@@ -1,0 +1,27 @@
+---
+language: node_js
+node_js:
+  - "10"
+
+dist: trusty
+
+addons:
+  chrome: stable
+
+cache:
+  directories:
+    - $HOME/.npm
+
+env:
+  global:
+    # See https://git.io/vdao3 for details.
+    - JOBS=1
+
+branches:
+  only:
+    - master
+
+script:
+  - npm run lint:hbs
+  - npm run lint:js
+  - npm test

--- a/test-packages/my-app-with-custom-write-path/.watchmanconfig
+++ b/test-packages/my-app-with-custom-write-path/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["tmp", "dist"]
+}

--- a/test-packages/my-app-with-custom-write-path/README.md
+++ b/test-packages/my-app-with-custom-write-path/README.md
@@ -1,0 +1,57 @@
+# my-app
+
+This README outlines the details of collaborating on this Ember application.
+A short introduction of this app could easily go here.
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](https://git-scm.com/)
+* [Node.js](https://nodejs.org/) (with npm)
+* [Ember CLI](https://ember-cli.com/)
+* [Google Chrome](https://google.com/chrome/)
+
+## Installation
+
+* `git clone <repository-url>` this repository
+* `cd my-app`
+* `npm install`
+
+## Running / Development
+
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
+* Visit your tests at [http://localhost:4200/tests](http://localhost:4200/tests).
+
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
+
+* `ember test`
+* `ember test --server`
+
+### Linting
+
+* `npm run lint:hbs`
+* `npm run lint:js`
+* `npm run lint:js -- --fix`
+
+### Building
+
+* `ember build` (development)
+* `ember build --environment production` (production)
+
+### Deploying
+
+Specify what it takes to deploy your app.
+
+## Further Reading / Useful Links
+
+* [ember.js](https://emberjs.com/)
+* [ember-cli](https://ember-cli.com/)
+* Development Browser Extensions
+  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)

--- a/test-packages/my-app-with-custom-write-path/README.md
+++ b/test-packages/my-app-with-custom-write-path/README.md
@@ -1,4 +1,4 @@
-# my-app
+# my-app-with-custom-write-path
 
 This README outlines the details of collaborating on this Ember application.
 A short introduction of this app could easily go here.
@@ -15,7 +15,7 @@ You will need the following things properly installed on your computer.
 ## Installation
 
 * `git clone <repository-url>` this repository
-* `cd my-app`
+* `cd my-app-with-custom-write-path`
 * `npm install`
 
 ## Running / Development

--- a/test-packages/my-app-with-custom-write-path/app/app.js
+++ b/test-packages/my-app-with-custom-write-path/app/app.js
@@ -1,0 +1,12 @@
+import Application from '@ember/application';
+import Resolver from 'ember-resolver';
+import loadInitializers from 'ember-load-initializers';
+import config from './config/environment';
+
+export default class App extends Application {
+  modulePrefix = config.modulePrefix;
+  podModulePrefix = config.podModulePrefix;
+  Resolver = Resolver;
+}
+
+loadInitializers(App, config.modulePrefix);

--- a/test-packages/my-app-with-custom-write-path/app/index.html
+++ b/test-packages/my-app-with-custom-write-path/app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>MyApp</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/my-app.css">
+
+    {{content-for "head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/my-app.js"></script>
+
+    {{content-for "body-footer"}}
+  </body>
+</html>

--- a/test-packages/my-app-with-custom-write-path/app/index.html
+++ b/test-packages/my-app-with-custom-write-path/app/index.html
@@ -10,7 +10,7 @@
     {{content-for "head"}}
 
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/my-app.css">
+    <link integrity="" rel="stylesheet" href="{{rootURL}}assets/my-app-with-custom-write-path.css">
 
     {{content-for "head-footer"}}
   </head>
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/my-app.js"></script>
+    <script src="{{rootURL}}assets/my-app-with-custom-write-path.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/test-packages/my-app-with-custom-write-path/app/router.js
+++ b/test-packages/my-app-with-custom-write-path/app/router.js
@@ -1,0 +1,10 @@
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+
+Router.map(function() {
+});

--- a/test-packages/my-app-with-custom-write-path/app/templates/application.hbs
+++ b/test-packages/my-app-with-custom-write-path/app/templates/application.hbs
@@ -1,0 +1,5 @@
+{{!-- The following component displays Ember's default welcome message. --}}
+<WelcomePage />
+{{!-- Feel free to remove this! --}}
+
+{{outlet}}

--- a/test-packages/my-app-with-custom-write-path/app/utils/my-covered-util.js
+++ b/test-packages/my-app-with-custom-write-path/app/utils/my-covered-util.js
@@ -1,0 +1,3 @@
+export default function myCoveredUtil() {
+  return true;
+}

--- a/test-packages/my-app-with-custom-write-path/app/utils/my-uncovered-util.js
+++ b/test-packages/my-app-with-custom-write-path/app/utils/my-uncovered-util.js
@@ -1,0 +1,3 @@
+export default function myUncoveredUtil() {
+  return true;
+}

--- a/test-packages/my-app-with-custom-write-path/config/coverage.js
+++ b/test-packages/my-app-with-custom-write-path/config/coverage.js
@@ -1,0 +1,4 @@
+module.exports = {
+  reporters: ['lcov', 'html', 'text', 'json-summary'],
+  writePath: '/custom/test-write-path'
+};

--- a/test-packages/my-app-with-custom-write-path/config/environment.js
+++ b/test-packages/my-app-with-custom-write-path/config/environment.js
@@ -1,0 +1,51 @@
+'use strict';
+
+module.exports = function(environment) {
+  let ENV = {
+    modulePrefix: 'my-app-with-custom-write-path',
+    environment,
+    rootURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. EMBER_NATIVE_DECORATOR_SUPPORT: true
+      },
+      EXTEND_PROTOTYPES: {
+        // Prevent Ember Data from overriding Date.parse.
+        Date: false
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
+  }
+
+  if (environment === 'production') {
+    // here you can enable a production-specific feature
+  }
+
+  return ENV;
+};

--- a/test-packages/my-app-with-custom-write-path/config/optional-features.json
+++ b/test-packages/my-app-with-custom-write-path/config/optional-features.json
@@ -1,0 +1,6 @@
+{
+  "application-template-wrapper": false,
+  "default-async-observers": true,
+  "jquery-integration": false,
+  "template-only-glimmer-components": true
+}

--- a/test-packages/my-app-with-custom-write-path/config/targets.js
+++ b/test-packages/my-app-with-custom-write-path/config/targets.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const browsers = [
+  'last 1 Chrome versions',
+  'last 1 Firefox versions',
+  'last 1 Safari versions'
+];
+
+const isCI = !!process.env.CI;
+const isProduction = process.env.EMBER_ENV === 'production';
+
+if (isCI || isProduction) {
+  browsers.push('ie 11');
+}
+
+module.exports = {
+  browsers
+};

--- a/test-packages/my-app-with-custom-write-path/custom-dir-in-repo-addon.js
+++ b/test-packages/my-app-with-custom-write-path/custom-dir-in-repo-addon.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs-extra');
+const fixturify = require('fixturify');
+
+class InRepoAddon {
+  static async generate(app, name) {
+    let args = ['generate', 'in-repo-addon', name];
+    await app.runEmberCommand.apply(app, args);
+
+    let addon = new InRepoAddon(app, name);
+
+    // Move generated addon stubs from /lib to /local-lib
+    await fs.move(
+      path.join(app.path, 'lib', name, 'package.json'),
+      path.join(addon.path, 'package.json')
+    );
+
+    await fs.move(path.join(app.path, 'lib', name, 'index.js'), path.join(addon.path, 'index.js'));
+
+    app.editPackageJSON(pkg => {
+      pkg['ember-addon'].paths = [path.join('local-lib', 'addons', addon.name)];
+    });
+
+    addon.editPackageJSON(pkg => (pkg.dependencies = { 'ember-cli-htmlbars': '*' }));
+
+    return addon;
+  }
+
+  constructor(app, name) {
+    this.name = name;
+    this.app = app;
+    this.path = path.join(app.path, 'local-lib', 'addons', name);
+  }
+
+  editPackageJSON(editor) {
+    let packageJSONPath = path.join(this.path, 'package.json');
+    let pkg = fs.readJsonSync(packageJSONPath);
+    editor(pkg);
+    fs.writeJsonSync(packageJSONPath, pkg);
+  }
+
+  writeFixture(fixture) {
+    fixturify.writeSync(this.path, fixture);
+  }
+
+  nest(addon) {
+    this.editPackageJSON(pkg => {
+      pkg['ember-addon'] = pkg['ember-addon'] || {};
+      pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+      pkg['ember-addon'].paths.push(`../${addon.name}`);
+    });
+  }
+
+  async generateNestedAddon(name) {
+    // Generate another in-repo-addon at the app level...
+    let args = Array.prototype.slice.call(arguments);
+    args.unshift(this.app);
+    let addon = await InRepoAddon.generate.apply(null, args);
+
+    // Remove the in-repo-addon from the app...
+    this.app.editPackageJSON(pkg => {
+      pkg['ember-addon'].paths = pkg['ember-addon'].paths.filter(path => path !== `lib/${name}`);
+    });
+
+    // Add the in-repo-addon to this engine.
+    this.editPackageJSON(pkg => {
+      pkg['ember-addon'] = pkg['ember-addon'] || {};
+      pkg['ember-addon'].paths = pkg['ember-addon'].paths || [];
+      pkg['ember-addon'].paths.push(`../${name}`);
+    });
+
+    return addon;
+  }
+}
+
+module.exports = InRepoAddon;

--- a/test-packages/my-app-with-custom-write-path/ember-cli-build.js
+++ b/test-packages/my-app-with-custom-write-path/ember-cli-build.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+  let app = new EmberApp(defaults, {
+    babel: {
+      plugins: [
+        ...require('ember-cli-code-coverage').buildBabelPlugin(),
+      ],
+    },
+  });
+
+  // Use `app.import` to add additional libraries to the generated
+  // output files.
+  //
+  // If you need to use different assets in different
+  // environments, specify an object as the first parameter. That
+  // object's keys should be the environment name and the values
+  // should be the asset to use in that environment.
+  //
+  // If the library that you are including contains AMD or ES6
+  // modules that you would like to import into your application
+  // please specify an object with the list of modules as keys
+  // along with the exports of each module as its value.
+
+  return app.toTree();
+};

--- a/test-packages/my-app-with-custom-write-path/package.json
+++ b/test-packages/my-app-with-custom-write-path/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "my-app-with-custom-write-path",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Small description for my-app-with-custom-write-path goes here",
+  "repository": "",
+  "license": "MIT",
+  "author": "",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build --environment=production",
+    "lint:hbs": "ember-template-lint .",
+    "lint:js": "eslint .",
+    "start": "ember serve",
+    "test": "ember test"
+  },
+  "devDependencies": {
+    "@ember/optional-features": "^1.3.0",
+    "@glimmer/component": "^1.0.0",
+    "@glimmer/tracking": "^1.0.0",
+    "babel-eslint": "^10.0.3",
+    "broccoli-asset-rev": "^3.0.0",
+    "ember-auto-import": "^1.5.3",
+    "ember-cli": "~3.16.2",
+    "ember-cli-app-version": "^3.2.0",
+    "ember-cli-babel": "^7.17.2",
+    "ember-cli-code-coverage": "2.0.0-beta.4",
+    "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-eslint": "^5.1.0",
+    "ember-cli-htmlbars": "^4.2.2",
+    "ember-cli-inject-live-reload": "^2.0.2",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-template-lint": "^1.0.0-beta.3",
+    "ember-cli-uglify": "^3.0.0",
+    "ember-data": "~3.16.0",
+    "ember-exam": "^5.0.1",
+    "ember-export-application-global": "^2.0.1",
+    "ember-fetch": "^7.0.0",
+    "ember-load-initializers": "^2.1.1",
+    "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-qunit": "^4.6.0",
+    "ember-resolver": "^7.0.0",
+    "ember-source": "~3.16.0",
+    "ember-welcome-page": "^4.0.0",
+    "eslint-plugin-ember": "^7.7.2",
+    "eslint-plugin-node": "^11.0.0",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^1.0.0"
+  },
+  "engines": {
+    "node": "10.* || >= 12"
+  },
+  "ember": {
+    "edition": "octane"
+  }
+}

--- a/test-packages/my-app-with-custom-write-path/testem.js
+++ b/test-packages/my-app-with-custom-write-path/testem.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  test_page: 'tests/index.html?hidepassed',
+  disable_watching: true,
+  launch_in_ci: [
+    'Chrome'
+  ],
+  launch_in_dev: [
+    'Chrome'
+  ],
+  browser_start_timeout: 120,
+  browser_args: {
+    Chrome: {
+      ci: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.CI ? '--no-sandbox' : null,
+        '--headless',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
+  }
+};

--- a/test-packages/my-app-with-custom-write-path/tests/index.html
+++ b/test-packages/my-app-with-custom-write-path/tests/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>MyApp Tests</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for "head"}}
+    {{content-for "test-head"}}
+
+    <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/my-app.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
+
+    {{content-for "head-footer"}}
+    {{content-for "test-head-footer"}}
+  </head>
+  <body>
+    {{content-for "body"}}
+    {{content-for "test-body"}}
+
+    <script src="/testem.js" integrity=""></script>
+    <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/test-support.js"></script>
+    <script src="{{rootURL}}assets/my-app.js"></script>
+    <script src="{{rootURL}}assets/tests.js"></script>
+
+    {{content-for "body-footer"}}
+    {{content-for "test-body-footer"}}
+  </body>
+</html>

--- a/test-packages/my-app-with-custom-write-path/tests/index.html
+++ b/test-packages/my-app-with-custom-write-path/tests/index.html
@@ -11,7 +11,7 @@
     {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/my-app.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/my-app-with-custom-write-path.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
     {{content-for "head-footer"}}
@@ -24,7 +24,7 @@
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
-    <script src="{{rootURL}}assets/my-app.js"></script>
+    <script src="{{rootURL}}assets/my-app-with-custom-write-path.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>
 
     {{content-for "body-footer"}}

--- a/test-packages/my-app-with-custom-write-path/tests/test-helper.js
+++ b/test-packages/my-app-with-custom-write-path/tests/test-helper.js
@@ -1,0 +1,15 @@
+import Application from '../app';
+import config from '../config/environment';
+import { setApplication } from '@ember/test-helpers';
+import { start } from 'ember-qunit';
+import QUnit from 'qunit';
+import { forceModulesToBeLoaded, sendCoverage } from 'ember-cli-code-coverage/test-support';
+
+QUnit.done(async function() {
+  forceModulesToBeLoaded();
+  await sendCoverage(undefined, '/custom/test-write-path');
+});
+
+setApplication(Application.create(config.APP));
+
+start();

--- a/test-packages/my-app-with-custom-write-path/tests/unit/utils/my-covered-util-test.js
+++ b/test-packages/my-app-with-custom-write-path/tests/unit/utils/my-covered-util-test.js
@@ -1,0 +1,10 @@
+import myCoveredUtil from 'my-app/utils/my-covered-util';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | my covered util');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = myCoveredUtil();
+  assert.ok(result);
+});

--- a/test-packages/my-app-with-custom-write-path/tests/unit/utils/my-covered-util-test.js
+++ b/test-packages/my-app-with-custom-write-path/tests/unit/utils/my-covered-util-test.js
@@ -1,4 +1,4 @@
-import myCoveredUtil from 'my-app/utils/my-covered-util';
+import myCoveredUtil from 'my-app-with-custom-write-path/utils/my-covered-util';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | my covered util');


### PR DESCRIPTION
This PR adds support for `/write-coverage` endpoint to be configurable through `coverage.js` config.
As of now, the endpoint for posting code coverage data is hardcoded to `/write-coverage`.

Details:
- Added a new config option `writePath` which defaults to `/write-coverage` if not provided.
- Updated `sendCoverage()` definition to accept `writePath` as second param.
- Added new test-package `my-app-with-custom-write-path` & new test file to test the usage of this new config option.
- Updated README accordingly.