### PR TITLE
Added ability to pass coverage api value and report type from client app config

### DIFF
--- a/packages/ember-cli-code-coverage/addon-test-support/index.js
+++ b/packages/ember-cli-code-coverage/addon-test-support/index.js
@@ -66,7 +66,7 @@ export function forceModulesToBeLoaded(filterFunction) {
 
 export async function sendCoverage(callback, options) {
   let coverageData = window.__coverage__; //eslint-disable-line no-undef
-  let { coverageApiPath, isHtmlReport } = options;
+  let { coverageApiPath, isHtmlReportGenerated } = options;
   if (!coverageApiPath) {
     coverageApiPath = '/write-coverage';
   }
@@ -89,7 +89,7 @@ export async function sendCoverage(callback, options) {
     body,
   });
   let responseData = await response.json();
-  if (isHtmlReport) {
+  if (isHtmlReportGenerated) {
     writeCoverageInfo(responseData);
   }
 

--- a/packages/ember-cli-code-coverage/addon-test-support/index.js
+++ b/packages/ember-cli-code-coverage/addon-test-support/index.js
@@ -64,8 +64,12 @@ export function forceModulesToBeLoaded(filterFunction) {
   });
 }
 
-export async function sendCoverage(callback, coverageApiPath = '/write-coverage') {
+export async function sendCoverage(callback, options) {
   let coverageData = window.__coverage__; //eslint-disable-line no-undef
+  let { coverageApiPath, isHtmlReport } = options;
+  if (!coverageApiPath) {
+    coverageApiPath = '/write-coverage';
+  }
 
   if (coverageData === undefined) {
     if (callback) {
@@ -85,7 +89,9 @@ export async function sendCoverage(callback, coverageApiPath = '/write-coverage'
     body,
   });
   let responseData = await response.json();
-  writeCoverageInfo(responseData);
+  if (isHtmlReport) {
+    writeCoverageInfo(responseData);
+  }
 
   if (callback) {
     callback();

--- a/packages/ember-cli-code-coverage/addon-test-support/index.js
+++ b/packages/ember-cli-code-coverage/addon-test-support/index.js
@@ -64,7 +64,7 @@ export function forceModulesToBeLoaded(filterFunction) {
   });
 }
 
-export async function sendCoverage(callback) {
+export async function sendCoverage(callback, coverageApiPath = '/write-coverage') {
   let coverageData = window.__coverage__; //eslint-disable-line no-undef
 
   if (coverageData === undefined) {
@@ -77,7 +77,7 @@ export async function sendCoverage(callback) {
 
   let body = JSON.stringify(coverageData || {});
 
-  let response = await fetch('/write-coverage', {
+  let response = await fetch(coverageApiPath, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/ember-cli-code-coverage/addon-test-support/index.js
+++ b/packages/ember-cli-code-coverage/addon-test-support/index.js
@@ -66,7 +66,7 @@ export function forceModulesToBeLoaded(filterFunction) {
 
 export async function sendCoverage(callback, options) {
   let coverageData = window.__coverage__; //eslint-disable-line no-undef
-  let { coverageApiPath, isHtmlReportGenerated } = options;
+  let { coverageApiPath, isHtmlReportNotGenerated } = options; // if isHtmlReportNotGenerated is null/undefined, writeCoverageInfo will be called; if it is explicitly passed as `true`, writeCoverageInfo will not be called
   if (!coverageApiPath) {
     coverageApiPath = '/write-coverage';
   }
@@ -89,7 +89,7 @@ export async function sendCoverage(callback, options) {
     body,
   });
   let responseData = await response.json();
-  if (isHtmlReportGenerated) {
+  if (!isHtmlReportNotGenerated) {
     writeCoverageInfo(responseData);
   }
 

--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -9,11 +9,20 @@ const path = require('path');
 const crypto = require('crypto');
 const fs = require('fs-extra');
 
-const WRITE_COVERAGE = '/write-coverage';
-
 function logError(err, req, res, next) {
   console.error(err.stack);
   next(err);
+}
+
+/**
+ * This function fetches the API path to write coverage
+ * This can be passed from the client application using the key `coverageApiPath` in the file config/coverage.js
+ * Default value will be set to `/write-coverage`
+ */
+
+function getCoverageApiPath(configPath) {
+  let config = getConfig(configPath);
+  return config.coverageApiPath;
 }
 
 /*
@@ -183,8 +192,10 @@ function coverageHandler(map, options, req, res) {
 // Used when app is in dev mode (`ember serve`).
 // Creates a new coverage map on every request.
 function serverMiddleware(app, options) {
+  let coverageApiPath = getCoverageApiPath(options.configPath);
+
   app.post(
-    WRITE_COVERAGE,
+    coverageApiPath,
     bodyParser,
     (req, res) => {
       let map = libCoverage.createCoverageMap();
@@ -199,9 +210,10 @@ function serverMiddleware(app, options) {
 // Collects the coverage on each request and merges it into the coverage map.
 function testMiddleware(app, options) {
   let map = libCoverage.createCoverageMap();
+  let coverageApiPath = getCoverageApiPath(options.configPath);
 
   app.post(
-    WRITE_COVERAGE,
+    coverageApiPath,
     bodyParser,
     (req, res) => {
       coverageHandler(map, options, req, res);

--- a/packages/ember-cli-code-coverage/lib/config.js
+++ b/packages/ember-cli-code-coverage/lib/config.js
@@ -40,6 +40,7 @@ function getDefaultConfig() {
     coverageFolder: 'coverage',
     excludes: ['*/mirage/**/*'],
     reporters: ['html', 'lcov'],
+    coverageApiPath: '/write-coverage',
   };
 }
 


### PR DESCRIPTION
Added the ability to pass the value of the API from the client application instead of using `write-coverage` always [as discussed](https://github.com/kategengler/ember-cli-code-coverage/issues/147#issuecomment-1302348256).
The default will be set to `write-coverage` just in case the value is not passed from the client app.
Tested this with my app and it's working as expected after adding the `coverageApiPath` in my app's config/coverage.js
![image](https://user-images.githubusercontent.com/12690997/202557506-1f452dca-e8bc-491f-b4e2-6ee32e407832.png)

