### PR TITLE
Increase coverage payload limit

### DIFF
--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const bodyParser = require('body-parser').json({ limit: '50mb' });
+const bodyParser = require('body-parser').json({ limit: '500mb' });
 const libCoverage = require('istanbul-lib-coverage');
 const libReport = require('istanbul-lib-report');
 const reports = require('istanbul-reports');


### PR DESCRIPTION
Prior limit was 50mb. In a large traditional Ember app the payload may end up between 10 and 20mb so this is a good limit. However, with ember-template-imports we end up with inline sourcemaps which can increase the payload size by an order of magnitude. This increases the limit accordingly.