### PR TITLE
use `moduleName` instead of `name` when building namespace mappings

### DIFF
--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -86,9 +86,10 @@ module.exports = {
           item.root,
           item.treePaths['addon-test-support']
         );
-        rootNamespaceMappings.set(item.name, addonPath);
+        const moduleName = item.moduleName();
+        rootNamespaceMappings.set(moduleName, addonPath);
         rootNamespaceMappings.set(
-          path.join(item.name, 'test-support'),
+          path.join(moduleName, 'test-support'),
           addonTestSupportPath
         );
       }


### PR DESCRIPTION
If an addon overrides `moduleName` to be different from `name`, the code coverage would be all 0. This PR changes `item.name` to `item.moduleName()`. `moduleName` returns `name` by default so this should cover both cases.