### PR TITLE
Allow configuration for `includes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Configuration is optional. It should be put in a file at `config/coverage.js` (`
   options to `lcov` with a different `projectRoot`: `[['lcov', { projectRoot:
   '/packages/addon' }], 'html']`
 
+- `includes`: Defaults to `['**/*']`. An array of globs to include in
+  instrumentation. Sometimes its more useful to constrain `includes` over using `excludes`.
+
 - `excludes`: Defaults to `['*/mirage/**/*']`. An array of globs to exclude from instrumentation. Useful to exclude files from coverage statistics.
 
 - `extension`: Defaults to `['.gjs', '.gts', '.js', '.ts', '.cjs', '.mjs', '.mts', '.cts']`. Tell Istanbul to instrument only files with the provided extensions.

--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -28,6 +28,7 @@ module.exports = {
    */
   buildBabelPlugin(opts = {}) {
     let cwd = opts.cwd || process.cwd();
+    let include = ['**/*'];
     let exclude = ['*/mirage/**/*', '*/node_modules/**/*'];
     let extension = [
       '.gjs',
@@ -50,6 +51,10 @@ module.exports = {
 
     if (fs.existsSync(path.join(cwd, configBase, 'coverage.js'))) {
       let config = require(path.join(cwd, configBase, 'coverage.js'));
+
+      if (config.includes) {
+        include = config.includes;
+      }
 
       if (config.excludes) {
         exclude = config.excludes;
@@ -89,7 +94,7 @@ module.exports = {
     return [
       // String lookup is needed to workaround https://github.com/embroider-build/embroider/issues/1525
       path.resolve(__dirname, 'lib/gjs-gts-istanbul-ignore-template-plugin'),
-      [IstanbulPlugin, { cwd, include: '**/*', exclude, extension }],
+      [IstanbulPlugin, { cwd, include, exclude, extension }],
     ];
   },
 


### PR DESCRIPTION
I'm using `ec-code-coverage` in a monorepo with v1 addons and I see "unwanted guests" in my coverage, which are local addon dependencies. I figured it is far more straight-forward to constrain the `include` rather than doing `exclude` gymnastics.

On top, given how v1 addons are built, putting paths into `excludes` isn't going to be the path that is checked against. Logging here: https://github.com/istanbuljs/babel-plugin-istanbul/blob/37bb294cf433ca327572a2c3e1e4e6c32484c16e/src/index.js#L109 reveals this:

```
path/to/package/<pkg-name>/...
path/to/package/<dep-name>/...
path/to/package/<@scope/dep-name>/...
```

To ease gymnastics, this PR allows for explicit `includes`.

Let me know, what else is needed.