### PR TITLE
feature: template coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - uses: pnpm/action-setup@v2
         with:
           version: 9

--- a/README.md
+++ b/README.md
@@ -153,14 +153,152 @@ Steps:
 ```
 ## ember-template-imports integration
 
-* in `ember-cli-build.js
-```
+* in `ember-cli-build.js`
+```js
   const app = new EmberApp(defaults, {
     'ember-template-imports': {
       inline_source_map: true,
     },
   });
 ```
+
+## Template Coverage
+
+This addon supports branch coverage for Glimmer/Handlebars templates (`.hbs` files and `<template>` tags in `.gjs`/`.gts` files). When `COVERAGE=true`, templates are automatically instrumented during compilation to track which branches are executed.
+
+### What is tracked
+
+- **Block conditionals**: `{{#if}}`, `{{#unless}}` (with and without `{{else}}`)
+- **Inline conditionals**: `{{if condition "yes" "no"}}`, `(if condition "a" "b")`, and the `unless` equivalents
+- **List branches**: `{{#each}}`/`{{#each-in}}` with `{{else}}` (items vs empty list)
+- **Chained conditionals**: `{{else if}}` chains
+- **Named blocks (slots)**: `<:header>`, `<:body>`, `<:footer>`, etc. -- tracks whether each named block was rendered
+- **Default blocks**: `<MyComponent>content</MyComponent>` -- tracks whether the implicit default block content was rendered. Components are detected by uppercase tags, dotted paths (`<foo.bar>`), `@`-prefixed arguments (`<my-thing @value={{1}}>`), or block params (`<my-thing as |item|>`)
+
+### How it works
+
+A Glimmer AST plugin runs at build time and:
+1. Injects `{{coverageInit}}` at the template root to register an Istanbul-compatible coverage object in `window.__coverage__`
+2. Injects `{{coverageMark}}` at the start of each block branch body to record block branch hits
+3. Wraps inline conditional conditions with `(coverageCond)` to record inline branch hits reactively
+
+The coverage data integrates seamlessly with the existing Istanbul pipeline, appearing in the same HTML/LCOV/JSON reports alongside JavaScript coverage.
+
+### Setup for .hbs files
+
+No additional setup is needed. The AST plugin is registered automatically via `setupPreprocessorRegistry` when the addon is installed. Branch coverage for `.hbs` files works out of the box.
+
+### Setup for .gjs/.gts files (strict mode)
+
+For `.gjs`/`.gts` files using `<template>` tags, coverage helpers need to be in JavaScript scope. The `buildBabelPlugin()` method already includes a Babel plugin that injects the necessary imports automatically. No extra configuration is required if you already have `buildBabelPlugin()` in your `ember-cli-build.js`.
+
+### Manual setup for babel-plugin-ember-template-compilation
+
+If you configure `babel-plugin-ember-template-compilation` directly (e.g., in Embroider v2 apps), you can add the AST plugin as a transform:
+
+```js
+// babel.config.js or similar
+const coverage = require('ember-cli-code-coverage');
+
+module.exports = {
+  plugins: [
+    // Coverage babel plugins (includes import injection for .gjs/.gts)
+    ...coverage.buildBabelPlugin({ embroider: true }),
+
+    // Template compilation with coverage AST transform
+    ['babel-plugin-ember-template-compilation', {
+      transforms: [
+        ...coverage.buildTemplateCoveragePlugin(),
+        // ...other transforms
+      ],
+    }],
+  ],
+};
+```
+
+### Example
+
+Given this template:
+```hbs
+{{#if @isLoggedIn}}
+  <p>Welcome, {{@user.name}}!</p>
+{{else}}
+  <p>Please log in.</p>
+{{/if}}
+
+<div class={{if @isActive "active" "inactive"}}>
+  {{#each @items as |item|}}
+    {{item.name}}
+  {{else}}
+    No items found.
+  {{/each}}
+</div>
+
+<PageLayout>
+  <:header>My App</:header>
+  <:sidebar>Navigation</:sidebar>
+  <:body>Main content</:body>
+</PageLayout>
+
+<Modal @isOpen={{@showModal}}>
+  <p>This is the default block content</p>
+</Modal>
+```
+
+The coverage report will show:
+- Branch 0 (`if`): whether `@isLoggedIn` was truthy and/or falsy
+- Branch 1 (`cond`): whether `@isActive` was truthy and/or falsy (inline conditional)
+- Branch 2 (`each`): whether `@items` had items and/or was empty
+- Branch 3 (`named-block`): whether `<:header>` was rendered
+- Branch 4 (`named-block`): whether `<:sidebar>` was rendered
+- Branch 5 (`named-block`): whether `<:body>` was rendered
+- Branch 6 (`default-block`): whether `<Modal>` rendered its default block content
+
+## V8 Compat Mode
+
+By default, this addon uses `babel-plugin-istanbul` to instrument all JS/TS files at build time. As an alternative, you can use **V8 compat mode** to skip Istanbul instrumentation entirely and rely on Chrome's built-in V8 code coverage for JS/TS files, while still using the template AST plugin for `.hbs` branch coverage.
+
+This is useful when you pair this addon with a V8 coverage collector like [`testem-code-coverage`](https://github.com/NullVoxPopuli/testem-code-coverage).
+
+### Benefits
+
+- **Faster builds** -- no Babel instrumentation pass for JS/TS files
+- **More accurate JS coverage** -- V8 bytecode-level coverage has no instrumentation side effects
+- **Template branch coverage preserved** -- the Glimmer AST plugin still instruments `{{#if}}`, `{{#unless}}`, inline `(if)`, named blocks, etc.
+
+### Setup
+
+1. Install a V8 coverage collector (e.g., `testem-code-coverage`)
+2. Pass `v8: true` to `buildBabelPlugin()`:
+
+```js
+// ember-cli-build.js
+let app = new EmberApp(defaults, {
+  babel: {
+    plugins: [
+      ...require('ember-cli-code-coverage').buildBabelPlugin({ v8: true }),
+    ],
+  },
+});
+```
+
+3. Configure your V8 collector (see its docs for Testem integration)
+
+### How it works
+
+In V8 compat mode, `buildBabelPlugin({ v8: true })` returns only the template coverage import plugin (for `.gjs`/`.gts` strict-mode support). It does **not** include `babel-plugin-istanbul` or the Istanbul ignore plugin.
+
+The coverage data flows from two sources:
+- **JS/TS files**: V8/CDP coverage collected externally, converted to Istanbul format by your V8 collector
+- **Template files** (`.hbs`, `<template>` in `.gjs`/`.gts`): Branch coverage from the AST plugin, written to `window.__coverage__` and sent via `/write-coverage`
+
+Both produce Istanbul-format output keyed by file path, so they merge cleanly in the final report.
+
+### Limitations
+
+- V8 coverage only works in **Chromium-based browsers** (Chrome, Edge). Firefox and Safari are not supported.
+- V8 coverage reports against compiled/bundled JS. Source map quality affects accuracy.
+- Template branch coverage still requires this addon's AST plugin and runtime helpers.
 
 ## Configuration
 

--- a/packages/ember-cli-code-coverage/addon/helpers/coverage-cond.js
+++ b/packages/ember-cli-code-coverage/addon/helpers/coverage-cond.js
@@ -1,0 +1,38 @@
+import { helper } from '@ember/component/helper';
+import recordBranchHit from 'ember-cli-code-coverage/utils/record-branch-hit';
+
+/**
+ * Template helper that records a branch hit for inline conditionals and
+ * returns the condition value as-is (pass-through).
+ *
+ * Unlike coverageMark which uses constant args (and is thus memoized by
+ * Glimmer), this helper receives a tracked condition argument. When the
+ * condition changes, Glimmer re-evaluates this helper, correctly recording
+ * both true and false branches over the component's lifecycle.
+ *
+ * Usage (injected by AST plugin, not meant for manual use):
+ *   {{if (coverageCond "file" 0 false condition) "yes" "no"}}
+ *   {{unless (coverageCond "file" 1 true condition) "no"}}
+ *
+ * @param {string} filePath - the module name / file path of the template
+ * @param {number} branchId - the branch index within the file
+ * @param {boolean} reversed - true for {{unless}} (falsy=location 0, truthy=location 1)
+ * @param {*} condition - the original condition value (passed through unchanged)
+ */
+export default helper(function coverageCond([
+  filePath,
+  branchId,
+  reversed,
+  condition,
+]) {
+  if (typeof window === 'undefined') {
+    return condition;
+  }
+
+  // For `if`: truthy → location 0 (consequent), falsy → location 1 (alternate)
+  // For `unless` (reversed): falsy → location 0 (body), truthy → location 1 (skip)
+  let locationId = reversed ? (condition ? 1 : 0) : condition ? 0 : 1;
+  recordBranchHit(filePath, branchId, locationId);
+
+  return condition;
+});

--- a/packages/ember-cli-code-coverage/addon/helpers/coverage-init.js
+++ b/packages/ember-cli-code-coverage/addon/helpers/coverage-init.js
@@ -1,0 +1,126 @@
+import { helper } from '@ember/component/helper';
+
+/**
+ * Template helper that registers an Istanbul-compatible coverage object
+ * for a template file in window.__coverage__.
+ *
+ * Injected automatically by the template coverage AST plugin at the root
+ * of each template that contains branch points.
+ *
+ * Usage (injected by AST plugin, not meant for manual use):
+ *   {{coverageInit "my-app/templates/application.hbs" "{...branchMapJSON}"}}
+ *
+ * NOTE: This helper uses constant arguments, so Glimmer's autotracking will
+ * only invoke it once per component instance. This is intentional -- we only
+ * need to register the coverage map once per template file.
+ *
+ * Handles .gts files with multiple <template> blocks that share the same
+ * module name: subsequent calls merge new branches into the existing entry
+ * instead of skipping.
+ *
+ * @param {string} filePath - the module name / file path of the template
+ * @param {string} branchMapJson - JSON-encoded Istanbul branchMap object
+ */
+export default helper(function coverageInit([filePath, branchMapJson]) {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  // Ensure __coverage__ exists. Istanbul's babel plugin normally creates this,
+  // but templates may render before any instrumented JS executes.
+  if (!window.__coverage__) {
+    window.__coverage__ = {};
+  }
+
+  let branchMap;
+  try {
+    branchMap = JSON.parse(branchMapJson);
+  } catch (e) {
+    return '';
+  }
+
+  // If coverage already exists for this file, merge new branches.
+  // This handles .gts files with multiple <template> blocks that share
+  // the same module name but have separate branch maps with unique IDs
+  // (assigned by the AST plugin's per-module counter).
+  if (window.__coverage__[filePath]) {
+    let existing = window.__coverage__[filePath];
+    if (!window.__templateCoverageStmtMap__) {
+      window.__templateCoverageStmtMap__ = {};
+    }
+    let branchStmtMap = window.__templateCoverageStmtMap__[filePath] || {};
+    let stmtKeys = Object.keys(existing.statementMap);
+    let stmtId =
+      stmtKeys.length > 0 ? Math.max.apply(null, stmtKeys.map(Number)) + 1 : 0;
+
+    let ids = Object.keys(branchMap);
+    for (let i = 0; i < ids.length; i++) {
+      let id = ids[i];
+      // Skip if this branch ID was already registered (e.g., component re-render)
+      if (existing.branchMap[id]) {
+        continue;
+      }
+      let branch = branchMap[id];
+      existing.branchMap[id] = branch;
+      existing.b[id] = branch.locations.map(function () {
+        return 0;
+      });
+      for (let j = 0; j < branch.locations.length; j++) {
+        branchStmtMap[id + ':' + j] = stmtId;
+        existing.statementMap[stmtId] = branch.locations[j];
+        existing.s[stmtId] = 0;
+        stmtId++;
+      }
+    }
+    window.__templateCoverageStmtMap__[filePath] = branchStmtMap;
+    return '';
+  }
+
+  // First template for this file — create the coverage entry.
+  // Build Istanbul branch counters and synthetic statement entries.
+  // Each branch location gets a corresponding statement so that Istanbul's
+  // line/statement coverage metrics reflect whether branch bodies were reached,
+  // instead of being vacuously 100% from an empty statementMap.
+  let b = {};
+  let statementMap = {};
+  let s = {};
+  let branchStmtMap = {};
+  let stmtId = 0;
+  let ids = Object.keys(branchMap);
+  for (let i = 0; i < ids.length; i++) {
+    let id = ids[i];
+    let branch = branchMap[id];
+    b[id] = branch.locations.map(function () {
+      return 0;
+    });
+    // Create a synthetic statement for each branch location and record
+    // the mapping so coverageMark/coverageCond can increment both b[] and s[].
+    for (let j = 0; j < branch.locations.length; j++) {
+      branchStmtMap[id + ':' + j] = stmtId;
+      statementMap[stmtId] = branch.locations[j];
+      s[stmtId] = 0;
+      stmtId++;
+    }
+  }
+
+  // Register Istanbul-compatible coverage object (only standard keys).
+  window.__coverage__[filePath] = {
+    path: filePath,
+    statementMap: statementMap,
+    s: s,
+    branchMap: branchMap,
+    b: b,
+    fnMap: {},
+    f: {},
+  };
+
+  // Store the branch-to-statement mapping separately so it doesn't
+  // leak into Istanbul JSON output. coverageMark/coverageCond use this
+  // to keep statement counters in sync with branch counters.
+  if (!window.__templateCoverageStmtMap__) {
+    window.__templateCoverageStmtMap__ = {};
+  }
+  window.__templateCoverageStmtMap__[filePath] = branchStmtMap;
+
+  return '';
+});

--- a/packages/ember-cli-code-coverage/addon/helpers/coverage-mark.js
+++ b/packages/ember-cli-code-coverage/addon/helpers/coverage-mark.js
@@ -1,0 +1,31 @@
+import { helper } from '@ember/component/helper';
+import recordBranchHit from 'ember-cli-code-coverage/utils/record-branch-hit';
+
+/**
+ * Template helper that increments an Istanbul branch coverage counter
+ * and its corresponding synthetic statement counter.
+ *
+ * Injected automatically by the template coverage AST plugin at the
+ * beginning of each branch body (if/else, unless, each with else,
+ * curly/angle-bracket component default blocks).
+ *
+ * Usage (injected by AST plugin, not meant for manual use):
+ *   {{coverageMark "my-app/templates/application.hbs" 0 1}}
+ *
+ * NOTE: This helper uses constant arguments, so Glimmer's autotracking will
+ * only invoke it once per component instance. For block-level branch coverage,
+ * a single invocation is sufficient to record that the branch was taken.
+ *
+ * @param {string} filePath - the module name / file path of the template
+ * @param {number} branchId - the branch index within the file
+ * @param {number} locationId - the location index within the branch (0=consequent, 1=alternate)
+ */
+export default helper(function coverageMark([filePath, branchId, locationId]) {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  recordBranchHit(filePath, branchId, locationId);
+
+  return '';
+});

--- a/packages/ember-cli-code-coverage/addon/utils/record-branch-hit.js
+++ b/packages/ember-cli-code-coverage/addon/utils/record-branch-hit.js
@@ -1,0 +1,30 @@
+/**
+ * Records a branch hit in the Istanbul coverage object and increments
+ * the corresponding synthetic statement counter for line coverage.
+ *
+ * Shared by coverageMark and coverageCond helpers to avoid duplication.
+ *
+ * @param {string} filePath - the template module name / file path
+ * @param {number} branchId - the branch index within the file
+ * @param {number} locationId - the location index within the branch
+ */
+export default function recordBranchHit(filePath, branchId, locationId) {
+  let coverage = window.__coverage__ && window.__coverage__[filePath];
+  if (!coverage || !coverage.b || !coverage.b[branchId]) {
+    return;
+  }
+
+  coverage.b[branchId][locationId] =
+    (coverage.b[branchId][locationId] || 0) + 1;
+
+  // Increment the synthetic statement counter for line coverage.
+  // The mapping is stored separately from the Istanbul coverage object
+  // to avoid polluting Istanbul JSON output.
+  let stmtMap =
+    window.__templateCoverageStmtMap__ &&
+    window.__templateCoverageStmtMap__[filePath];
+  let stmtId = stmtMap && stmtMap[branchId + ':' + locationId];
+  if (stmtId !== undefined && coverage.s) {
+    coverage.s[stmtId] = (coverage.s[stmtId] || 0) + 1;
+  }
+}

--- a/packages/ember-cli-code-coverage/app/helpers/coverage-cond.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverage-cond.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-cond';

--- a/packages/ember-cli-code-coverage/app/helpers/coverage-init.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverage-init.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-init';

--- a/packages/ember-cli-code-coverage/app/helpers/coverage-mark.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverage-mark.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-mark';

--- a/packages/ember-cli-code-coverage/app/helpers/coverageCond.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverageCond.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-cond';

--- a/packages/ember-cli-code-coverage/app/helpers/coverageInit.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverageInit.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-init';

--- a/packages/ember-cli-code-coverage/app/helpers/coverageMark.js
+++ b/packages/ember-cli-code-coverage/app/helpers/coverageMark.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-code-coverage/helpers/coverage-mark';

--- a/packages/ember-cli-code-coverage/index.js
+++ b/packages/ember-cli-code-coverage/index.js
@@ -3,9 +3,19 @@
 let path = require('path');
 let fs = require('fs-extra');
 let attachMiddleware = require('./lib/attach-middleware');
+let createTemplateCoveragePlugin = require('./lib/template-coverage-plugin');
 
 module.exports = {
   name: require('./package').name,
+
+  // Prevent ember-cli-babel from inheriting the host app's
+  // throwUnlessParallelizable when transpiling this addon's own files.
+  // Without this, apps with throwUnlessParallelizable: true would fail
+  // because _getAddonOptions falls through to app.options when
+  // this.parent.options is undefined.
+  options: {
+    babel: {},
+  },
 
   /**
     @example
@@ -25,6 +35,30 @@ module.exports = {
         },
       }
     };
+   */
+  /**
+    @example <caption>Default mode (Istanbul instrumentation for all files)</caption>
+    let app = new EmberApp(defaults, {
+      babel: {
+        plugins: [...require('ember-cli-code-coverage').buildBabelPlugin()],
+      },
+    });
+
+    @example <caption>V8 compat mode (template-only Istanbul, JS/TS via V8)</caption>
+    let app = new EmberApp(defaults, {
+      babel: {
+        plugins: [...require('ember-cli-code-coverage').buildBabelPlugin({ v8: true })],
+      },
+    });
+
+    @param {Object} [opts]
+    @param {string} [opts.cwd] - working directory (defaults to process.cwd())
+    @param {boolean} [opts.embroider] - set to true for Embroider builds
+    @param {boolean} [opts.v8] - V8 compat mode: skip babel-plugin-istanbul,
+      only include the template coverage import plugin for .gjs/.gts strict-mode
+      support. Use this when JS/TS coverage is collected externally via V8/CDP
+      (e.g. testem-code-coverage). Template branch coverage still works via the
+      AST plugin registered in setupPreprocessorRegistry.
    */
   buildBabelPlugin(opts = {}) {
     let cwd = opts.cwd || process.cwd();
@@ -68,6 +102,14 @@ module.exports = {
       return [];
     }
 
+    // V8 compat mode: skip Istanbul instrumentation entirely.
+    // Only include the import plugin so .gjs/.gts strict-mode templates can
+    // resolve the coverage helpers (coverageInit, coverageMark, coverageCond).
+    // JS/TS coverage is expected to come from an external V8/CDP collector.
+    if (opts.v8 === true) {
+      return [path.resolve(__dirname, 'lib/template-coverage-import-plugin')];
+    }
+
     if (opts.embroider === true) {
       try {
         // Attempt to import the utility @embroider/compat uses in >3.1 to locate the embroider working directory
@@ -85,12 +127,115 @@ module.exports = {
       }
     }
 
+    // Build the istanbul plugin entry as a standard [path, opts] tuple so it
+    // works in both standard Babel (Rollup, v2 addons) and broccoli-babel-transpiler
+    // (classic ember-cli). Attach _parallelBabel on the array so broccoli-babel-transpiler
+    // can reconstruct it in worker threads (arrays are objects in JS).
     const IstanbulPlugin = require.resolve('babel-plugin-istanbul');
+    const istanbulEntry = [
+      IstanbulPlugin,
+      { cwd, include: '**/*', exclude, extension },
+    ];
+    istanbulEntry._parallelBabel = {
+      requireFile: path.resolve(__dirname, 'lib/istanbul-plugin-wrapper'),
+      buildUsing: 'buildIstanbulPlugin',
+      params: { cwd, include: '**/*', exclude, extension },
+    };
+
     return [
+      // Inject coverage helper imports into .gjs/.gts files for strict-mode template support.
+      // Must run BEFORE babel-plugin-ember-template-compilation so imports are in scope.
+      path.resolve(__dirname, 'lib/template-coverage-import-plugin'),
       // String lookup is needed to workaround https://github.com/embroider-build/embroider/issues/1525
       path.resolve(__dirname, 'lib/gjs-gts-istanbul-ignore-template-plugin'),
-      [IstanbulPlugin, { cwd, include: '**/*', exclude, extension }],
+      istanbulEntry,
     ];
+  },
+
+  /**
+   * Returns the template coverage AST plugin for use with
+   * babel-plugin-ember-template-compilation transforms.
+   *
+   * @example
+   * // In ember-cli-build.js, for Embroider apps:
+   * plugins: [
+   *   ['babel-plugin-ember-template-compilation', {
+   *     transforms: [
+   *       ...require('ember-cli-code-coverage').buildTemplateCoveragePlugin(),
+   *     ],
+   *   }],
+   * ]
+   *
+   * @param {Object} [opts]
+   * @param {string} [opts.coverageEnvVar='COVERAGE'] - environment variable name
+   * @returns {Function[]} Array containing the AST plugin factory (empty if coverage disabled)
+   */
+  buildTemplateCoveragePlugin(opts = {}) {
+    let coverageEnvVar = opts.coverageEnvVar || 'COVERAGE';
+
+    if (process.env[coverageEnvVar] !== 'true') {
+      return [];
+    }
+
+    return [createTemplateCoveragePlugin({ coverageEnvVar })];
+  },
+
+  /**
+   * Register the template coverage AST plugin with ember-cli-htmlbars.
+   * This is called automatically by ember-cli for v1 addons.
+   * Covers .hbs files and .gjs/.gts files compiled through ember-cli-htmlbars.
+   */
+  setupPreprocessorRegistry(type, registry) {
+    // Only register for the parent (consuming app), not for 'self',
+    // to avoid double-registering the plugin.
+    if (type !== 'parent') {
+      return;
+    }
+
+    // Determine the coverage env var from config (if available)
+    let coverageEnvVar = 'COVERAGE';
+
+    try {
+      let cwd = this.project ? this.project.root : process.cwd();
+      let configBase = 'config';
+      let pkgJSON = fs.readJSONSync(path.join(cwd, 'package.json'));
+
+      if (pkgJSON['ember-addon'] && pkgJSON['ember-addon'].configPath) {
+        configBase = pkgJSON['ember-addon'].configPath;
+      }
+
+      if (fs.existsSync(path.join(cwd, configBase, 'coverage.js'))) {
+        let config = require(path.join(cwd, configBase, 'coverage.js'));
+        if (config.coverageEnvVar) {
+          coverageEnvVar = config.coverageEnvVar;
+        }
+      }
+    } catch (e) {
+      // Config not available yet, use default
+    }
+
+    // Register the AST plugin. The plugin itself checks the env var at runtime
+    // and no-ops if coverage is not enabled, so the build overhead is minimal.
+    // The parallelBabel property tells ember-cli-htmlbars how to reconstruct
+    // the plugin in worker threads for parallel template compilation.
+    registry.add('htmlbars-ast-plugin', {
+      name: 'ember-cli-code-coverage-template',
+      plugin: createTemplateCoveragePlugin({ coverageEnvVar }),
+      parallelBabel: {
+        requireFile: path.resolve(__dirname, 'lib/template-coverage-plugin'),
+        buildUsing: 'buildForParallel',
+        params: { coverageEnvVar },
+      },
+      baseDir: function () {
+        return __dirname;
+      },
+      cacheKey: function () {
+        return (
+          'ember-cli-code-coverage-template-' +
+          (process.env[coverageEnvVar] === 'true' ? 'on' : 'off')
+        );
+      },
+    });
   },
 
   includedCommands() {

--- a/packages/ember-cli-code-coverage/lib/attach-middleware.js
+++ b/packages/ember-cli-code-coverage/lib/attach-middleware.js
@@ -106,8 +106,33 @@ function adjustCoverageKey(
   if (embroiderTmpPathRegex.test(filepath)) {
     relativePath = normalizeRelativePath(root, filepath);
   } else if (relativePath.startsWith('..')) {
-    // This lives in a directory outside of the current one, likely a monorepo.
-    // In this case we can assume that the original path is correct.
+    // The path is outside project root. This can be either:
+    // (a) a monorepo path (absolute path to another package), or
+    // (b) a module name from template coverage (e.g., "my-app/templates/foo")
+    //     which is not a real filesystem path.
+    // For case (b), try to resolve via namespace mappings first.
+    if (!path.isAbsolute(filepath)) {
+      let segments = filepath.split('/');
+      let ns = filepath.startsWith('@')
+        ? segments.slice(0, 2).join('/')
+        : segments[0];
+      if (namespaceMappings.has(ns)) {
+        let rest = filepath.startsWith('@')
+          ? segments.slice(2)
+          : segments.slice(1);
+        let basePath = namespaceMappings.get(ns);
+        let baseFile = path.join(basePath, ...rest);
+        // Try with common template extensions
+        let extensions = ['', '.hbs', '.gjs', '.gts', '.js', '.ts'];
+        for (let ext of extensions) {
+          let resolved = baseFile + ext;
+          if (fs.existsSync(resolved)) {
+            return resolved;
+          }
+        }
+      }
+    }
+    // Fallback: monorepo path, return as-is.
     return filepath;
   }
 

--- a/packages/ember-cli-code-coverage/lib/gjs-gts-istanbul-ignore-template-plugin.js
+++ b/packages/ember-cli-code-coverage/lib/gjs-gts-istanbul-ignore-template-plugin.js
@@ -46,7 +46,7 @@ const gjsGtsTemplateIgnoreVisitor = {
   },
 };
 
-module.exports = function () {
+function gjsGtsIstanbulIgnoreTemplatePlugin() {
   return {
     visitor: {
       Program: {
@@ -71,4 +71,10 @@ module.exports = function () {
       },
     },
   };
+}
+
+gjsGtsIstanbulIgnoreTemplatePlugin._parallelBabel = {
+  requireFile: __filename,
 };
+
+module.exports = gjsGtsIstanbulIgnoreTemplatePlugin;

--- a/packages/ember-cli-code-coverage/lib/istanbul-plugin-wrapper.js
+++ b/packages/ember-cli-code-coverage/lib/istanbul-plugin-wrapper.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ * Wrapper for babel-plugin-istanbul that provides _parallelBabel metadata
+ * so the plugin can be used with ember-cli-babel's throwUnlessParallelizable.
+ *
+ * broccoli-babel-transpiler requires plugins to either be serializable or
+ * have a _parallelBabel property that tells workers how to reconstruct them.
+ * babel-plugin-istanbul doesn't provide this, so we wrap it.
+ *
+ * buildFromParallelApiInfo calls: buildIstanbulPlugin(params)
+ * The return value is used as the plugin entry in the Babel plugins array.
+ * We return [pluginFunction, opts] so Babel gets the standard tuple format.
+ */
+function buildIstanbulPlugin(opts) {
+  let istanbulPlugin = require('babel-plugin-istanbul');
+  // Handle both CJS default export and ESM interop
+  let plugin = istanbulPlugin.default || istanbulPlugin;
+  return [plugin, opts];
+}
+
+module.exports = { buildIstanbulPlugin };

--- a/packages/ember-cli-code-coverage/lib/template-coverage-import-plugin.js
+++ b/packages/ember-cli-code-coverage/lib/template-coverage-import-plugin.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Babel plugin that injects coverage helper imports into files with
+ * strict-mode templates.
+ *
+ * In strict-mode templates (<template> tag in .gjs/.gts, or template()
+ * calls in .ts/.js), helpers must be in JS scope to be referenced.
+ * This plugin detects any file that imports from '@ember/template-compiler'
+ * and adds:
+ *
+ *   import coverageInit from 'ember-cli-code-coverage/helpers/coverage-init';
+ *   import coverageMark from 'ember-cli-code-coverage/helpers/coverage-mark';
+ *   import coverageCond from 'ember-cli-code-coverage/helpers/coverage-cond';
+ *
+ * so the AST-plugin-injected {{coverageInit}}, {{coverageMark}}, and
+ * (coverageCond) invocations can resolve in strict mode.
+ *
+ * IMPORTANT: This plugin uses the pre() hook (not a visitor) to inject
+ * imports BEFORE babel-plugin-ember-template-compilation's pre() hook
+ * compiles templates and validates scope. Babel runs all plugins' pre()
+ * hooks in plugin order before the traversal phase. This plugin must be
+ * listed BEFORE babel-plugin-ember-template-compilation in the plugins array.
+ */
+function templateCoverageImportPlugin(babel) {
+  const t = babel.types;
+
+  const HELPER_IMPORTS = [
+    {
+      local: 'coverageInit',
+      source: 'ember-cli-code-coverage/helpers/coverage-init',
+    },
+    {
+      local: 'coverageMark',
+      source: 'ember-cli-code-coverage/helpers/coverage-mark',
+    },
+    {
+      local: 'coverageCond',
+      source: 'ember-cli-code-coverage/helpers/coverage-cond',
+    },
+  ];
+
+  return {
+    name: 'ember-cli-coverage-template-import',
+
+    // Use pre() instead of Program visitor so imports are injected before
+    // babel-plugin-ember-template-compilation's pre() compiles templates.
+    // Babel runs pre() hooks in plugin order, so as long as this plugin
+    // is listed first, imports are in scope when templates are compiled.
+    pre(file) {
+      const body = file.ast.program.body;
+
+      // Check if template() is imported from @ember/template-compiler.
+      // This covers .gjs/.gts files (processed by content-tag) AND
+      // .ts/.js files that use template() directly for strict-mode templates.
+      const hasTemplateImport = body.some(
+        (node) =>
+          node.type === 'ImportDeclaration' &&
+          node.source.value === '@ember/template-compiler'
+      );
+
+      if (!hasTemplateImport) {
+        return;
+      }
+
+      // Collect which imports are missing
+      const newImports = [];
+      for (const { local, source } of HELPER_IMPORTS) {
+        const alreadyImported = body.some(
+          (node) =>
+            node.type === 'ImportDeclaration' && node.source.value === source
+        );
+        if (!alreadyImported) {
+          newImports.push(
+            t.importDeclaration(
+              [t.importDefaultSpecifier(t.identifier(local))],
+              t.stringLiteral(source)
+            )
+          );
+        }
+      }
+
+      if (newImports.length > 0) {
+        // Insert after existing imports
+        let lastImportIndex = -1;
+        for (let i = 0; i < body.length; i++) {
+          if (body[i].type === 'ImportDeclaration') {
+            lastImportIndex = i;
+          }
+        }
+
+        for (let j = newImports.length - 1; j >= 0; j--) {
+          body.splice(lastImportIndex + 1, 0, newImports[j]);
+        }
+
+        // Force Babel to rebuild its scope analysis so that
+        // babel-plugin-ember-template-compilation (which runs its own
+        // traversal in pre()) can see our new imports as in-scope bindings.
+        // Without this, strict-mode template compilation fails because
+        // the scope was built before our imports were added.
+        if (file.path && file.path.scope) {
+          file.path.scope.crawl();
+        }
+      }
+    },
+  };
+}
+
+templateCoverageImportPlugin._parallelBabel = {
+  requireFile: __filename,
+};
+
+module.exports = templateCoverageImportPlugin;

--- a/packages/ember-cli-code-coverage/lib/template-coverage-plugin.js
+++ b/packages/ember-cli-code-coverage/lib/template-coverage-plugin.js
@@ -1,0 +1,409 @@
+'use strict';
+
+/**
+ * Glimmer AST plugin that instruments templates with coverage markers.
+ *
+ * Injects {{coverageInit filePath branchMapJSON}} at the template root to
+ * register an Istanbul-compatible coverage object in window.__coverage__.
+ *
+ * Injects {{coverageMark filePath branchId locationId}} at each branch point
+ * (if/else, unless, each with else) to record branch hits at runtime.
+ *
+ * Wraps inline (if cond a b) / (unless cond a) conditions with
+ * (coverageCond filePath branchId reversed condition) to track inline branches.
+ *
+ * Uses camelCase helper names so they work in both loose mode (.hbs, resolved
+ * by the Ember resolver which normalizes camelCase -> dash-case) and strict
+ * mode (.gjs/.gts, resolved from JS scope via the import plugin).
+ */
+
+/**
+ * Creates the template coverage AST plugin factory.
+ *
+ * @param {Object} options
+ * @param {string} [options.coverageEnvVar='COVERAGE'] - environment variable to check
+ * @returns {Function} Glimmer AST plugin factory (ASTPluginBuilder)
+ */
+function createTemplateCoveragePlugin(options) {
+  const coverageEnvVar = (options && options.coverageEnvVar) || 'COVERAGE';
+
+  // Track branch ID counters per module name so that multiple <template>
+  // blocks in the same .gts file get unique, non-colliding branch IDs.
+  const moduleBranchCounters = {};
+
+  return function templateCoveragePlugin(env) {
+    if (process.env[coverageEnvVar] !== 'true') {
+      return { name: 'ember-cli-coverage-noop', visitor: {} };
+    }
+
+    const moduleName = (env.meta && env.meta.moduleName) || 'unknown';
+    const b = env.syntax.builders;
+
+    let branchId = moduleBranchCounters[moduleName] || 0;
+    const branches = {};
+
+    // Block types that represent conditional branching
+    const CONDITIONAL_BLOCKS = { if: true, unless: true };
+
+    // Built-in block helpers that always render their body and are NOT
+    // component invocations. These should not be instrumented as branches.
+    const NON_BRANCH_BLOCKS = {
+      let: true,
+      with: true,
+      'in-element': true,
+      '-in-element': true,
+    };
+
+    /**
+     * Returns true if an ElementNode looks like a component invocation.
+     * A component is detected by any of:
+     * - Tag starts with an uppercase letter (e.g. <MyComponent>)
+     * - Tag contains a dot (e.g. <foo.bar>)
+     * - Element has @-prefixed attributes (e.g. <my-thing @value={{1}}>)
+     * - Element has block params (e.g. <my-thing as |item|>)
+     */
+    function isComponentElement(node) {
+      const tag = node.tag;
+      if (/^[A-Z]/.test(tag) || tag.indexOf('.') !== -1) {
+        return true;
+      }
+      // Check for @-prefixed attributes (component arguments)
+      if (
+        node.attributes &&
+        node.attributes.some(function (attr) {
+          return attr.name && attr.name.charAt(0) === '@';
+        })
+      ) {
+        return true;
+      }
+      // Check for block params (as |...|)
+      if (node.blockParams && node.blockParams.length > 0) {
+        return true;
+      }
+      return false;
+    }
+
+    function getLoc(node) {
+      if (!node || !node.loc) {
+        return { start: { line: 0, column: 0 }, end: { line: 0, column: 0 } };
+      }
+      const loc = node.loc;
+      // Support both SourceSpan API (.startPosition/.endPosition) and plain object (.start/.end)
+      const start = loc.startPosition || loc.start || { line: 0, column: 0 };
+      const end = loc.endPosition || loc.end || { line: 0, column: 0 };
+      return {
+        start: { line: start.line, column: start.column },
+        end: { line: end.line, column: end.column },
+      };
+    }
+
+    function createCoverageMark(branchIdx, locationIdx) {
+      return b.mustache(b.path('coverageMark'), [
+        b.string(moduleName),
+        b.number(branchIdx),
+        b.number(locationIdx),
+      ]);
+    }
+
+    function createCoverageCondWrapper(branchIdx, reversed, conditionNode) {
+      return b.sexpr(b.path('coverageCond'), [
+        b.string(moduleName),
+        b.number(branchIdx),
+        b.boolean(reversed),
+        conditionNode,
+      ]);
+    }
+
+    function instrumentConditionalBlock(node) {
+      const blockName = (node.path && node.path.original) || 'block';
+      const currentBranchId = branchId++;
+      const nodeLoc = getLoc(node);
+      const locations = [];
+
+      // Instrument the consequent (main block body)
+      if (node.program && node.program.body) {
+        const programLoc = getLoc(node.program);
+        locations.push({ start: programLoc.start, end: programLoc.end });
+        node.program.body.unshift(createCoverageMark(currentBranchId, 0));
+      }
+
+      // Instrument the alternate (else block).
+      // When there is no explicit {{else}}, we do NOT add an implicit else
+      // location. An absent else is treated as an empty block that is always
+      // "visited", so Istanbul won't report a phantom "else path not taken".
+      if (node.inverse && node.inverse.body) {
+        const inverseLoc = getLoc(node.inverse);
+        locations.push({ start: inverseLoc.start, end: inverseLoc.end });
+        node.inverse.body.unshift(createCoverageMark(currentBranchId, 1));
+      }
+
+      branches[currentBranchId] = {
+        type: blockName,
+        locations: locations,
+        loc: nodeLoc,
+      };
+    }
+
+    function instrumentEachBlock(node) {
+      // Only instrument {{#each}} / {{#each-in}} that have an {{else}} clause,
+      // since the each body is a loop (not a branch) but "items vs no items" is.
+      if (!node.inverse || !node.inverse.body) {
+        return;
+      }
+
+      const currentBranchId = branchId++;
+      const nodeLoc = getLoc(node);
+      const locations = [];
+
+      // Main body: list has items
+      if (node.program && node.program.body) {
+        const programLoc = getLoc(node.program);
+        locations.push({ start: programLoc.start, end: programLoc.end });
+        node.program.body.unshift(createCoverageMark(currentBranchId, 0));
+      }
+
+      // Else body: empty list
+      const inverseLoc = getLoc(node.inverse);
+      locations.push({ start: inverseLoc.start, end: inverseLoc.end });
+      node.inverse.body.unshift(createCoverageMark(currentBranchId, 1));
+
+      branches[currentBranchId] = {
+        type: 'each',
+        locations: locations,
+        loc: nodeLoc,
+      };
+    }
+
+    /**
+     * Instrument an inline conditional: (if cond a b) or (unless cond a b).
+     * Wraps the condition with (coverageCond filePath branchId reversed cond)
+     * so the helper can record which branch is taken and pass the condition through.
+     */
+    function instrumentInlineConditional(node) {
+      const blockName = node.path && node.path.original;
+
+      // Must have at least 2 params: condition + trueValue
+      if (!node.params || node.params.length < 2) {
+        return;
+      }
+
+      const currentBranchId = branchId++;
+      const nodeLoc = getLoc(node);
+      const reversed = blockName === 'unless';
+
+      // Point locations at the actual consequent/alternate values for accurate
+      // line/column mapping in Istanbul reports.
+      // location 0 = consequent value (params[1])
+      // location 1 = alternate value (params[2], or implicit undefined at end of expression)
+      const consequentLoc = node.params[1] ? getLoc(node.params[1]) : nodeLoc;
+      const alternateLoc = node.params[2]
+        ? getLoc(node.params[2])
+        : { start: nodeLoc.end, end: nodeLoc.end };
+      const locations = [
+        { start: consequentLoc.start, end: consequentLoc.end },
+        { start: alternateLoc.start, end: alternateLoc.end },
+      ];
+
+      branches[currentBranchId] = {
+        type: 'cond',
+        locations: locations,
+        loc: nodeLoc,
+      };
+
+      // Wrap the condition argument with coverageCond
+      node.params[0] = createCoverageCondWrapper(
+        currentBranchId,
+        reversed,
+        node.params[0]
+      );
+    }
+
+    /**
+     * Instrument a curly component block: {{#my-component}}...{{/my-component}}.
+     * The block body is an implicit default block (slot) that may or may not
+     * be yielded by the component.
+     */
+    function instrumentCurlyComponentBlock(node) {
+      const currentBranchId = branchId++;
+      const nodeLoc = getLoc(node);
+
+      // Inject coverageMark at the start of the program body
+      node.program.body.unshift(createCoverageMark(currentBranchId, 0));
+
+      // If the component has an inverse ({{else}}), instrument it too
+      const programLoc = getLoc(node.program);
+      if (node.inverse && node.inverse.body) {
+        const inverseLoc = getLoc(node.inverse);
+        branches[currentBranchId] = {
+          type: 'default-block',
+          locations: [
+            { start: programLoc.start, end: programLoc.end },
+            { start: inverseLoc.start, end: inverseLoc.end },
+          ],
+          loc: nodeLoc,
+        };
+        node.inverse.body.unshift(createCoverageMark(currentBranchId, 1));
+      } else {
+        branches[currentBranchId] = {
+          type: 'default-block',
+          locations: [
+            { start: programLoc.start, end: programLoc.end },
+            { start: nodeLoc.end, end: nodeLoc.end },
+          ],
+          loc: nodeLoc,
+        };
+      }
+    }
+
+    return {
+      name: 'ember-cli-code-coverage-template',
+      visitor: {
+        BlockStatement: function (node) {
+          const blockName = node.path && node.path.original;
+
+          if (CONDITIONAL_BLOCKS[blockName]) {
+            instrumentConditionalBlock(node);
+          } else if (blockName === 'each' || blockName === 'each-in') {
+            instrumentEachBlock(node);
+          } else if (NON_BRANCH_BLOCKS[blockName]) {
+            // Built-in blocks that always render — not branches, skip.
+          } else if (blockName && node.program && node.program.body) {
+            // Curly component invocation: {{#my-component}}...{{/my-component}}
+            // The block body is a default block (slot) that may or may not
+            // be yielded by the component. Instrument like a default-block.
+            instrumentCurlyComponentBlock(node);
+          }
+        },
+
+        SubExpression: function (node) {
+          const pathName = node.path && node.path.original;
+          if (pathName === 'if' || pathName === 'unless') {
+            instrumentInlineConditional(node);
+          }
+        },
+
+        MustacheStatement: function (node) {
+          const pathName = node.path && node.path.original;
+          // Only instrument inline {{if}} / {{unless}} (with params, not block form)
+          // Block form is handled by BlockStatement visitor
+          if (
+            (pathName === 'if' || pathName === 'unless') &&
+            node.params &&
+            node.params.length >= 2
+          ) {
+            instrumentInlineConditional(node);
+          }
+        },
+
+        ElementNode: function (node) {
+          if (!node.tag) {
+            return;
+          }
+
+          // Named blocks are ElementNodes with tags starting with ':'
+          // e.g. <:header>...</:header>, <:body>...</:body>
+          if (node.tag.charAt(0) === ':') {
+            const currentBranchId = branchId++;
+            const nodeLoc = getLoc(node);
+
+            // Inject coverageMark at the start of the named block's children
+            if (node.children) {
+              node.children.unshift(createCoverageMark(currentBranchId, 0));
+            }
+
+            // Istanbul expects branches to have at least 2 locations.
+            // Location 0 = rendered (the named block body).
+            // Location 1 = not rendered (implicit, zero-width at block end).
+            branches[currentBranchId] = {
+              type: 'named-block',
+              locations: [
+                { start: nodeLoc.start, end: nodeLoc.end },
+                { start: nodeLoc.end, end: nodeLoc.end },
+              ],
+              loc: nodeLoc,
+            };
+            return;
+          }
+
+          // Implicit default block: a component invocation with children that
+          // are NOT all named blocks.
+          if (
+            !isComponentElement(node) ||
+            !node.children ||
+            node.children.length === 0
+          ) {
+            return;
+          }
+
+          // Check whether all children are named blocks. If so, there is no
+          // implicit default block to instrument.
+          const hasNamedBlock = node.children.some(function (child) {
+            return (
+              child.type === 'ElementNode' &&
+              child.tag &&
+              child.tag.charAt(0) === ':'
+            );
+          });
+
+          // If any child is a named block, all non-whitespace children should
+          // be named blocks (Glimmer enforces this). So skip instrumentation
+          // to avoid interfering with named block semantics.
+          if (hasNamedBlock) {
+            return;
+          }
+
+          const currentBranchId = branchId++;
+          const nodeLoc = getLoc(node);
+
+          // Inject coverageMark at the start of the component's children
+          node.children.unshift(createCoverageMark(currentBranchId, 0));
+
+          // Istanbul expects branches to have at least 2 locations.
+          // Location 0 = rendered (the default block body).
+          // Location 1 = not rendered (implicit, zero-width at block end).
+          branches[currentBranchId] = {
+            type: 'default-block',
+            locations: [
+              { start: nodeLoc.start, end: nodeLoc.end },
+              { start: nodeLoc.end, end: nodeLoc.end },
+            ],
+            loc: nodeLoc,
+          };
+        },
+
+        Template: {
+          exit: function (node) {
+            // Save the counter so the next <template> in this module
+            // continues from where we left off (avoids branchId collisions).
+            moduleBranchCounters[moduleName] = branchId;
+
+            if (Object.keys(branches).length > 0) {
+              const initNode = b.mustache(b.path('coverageInit'), [
+                b.string(moduleName),
+                b.string(JSON.stringify(branches)),
+              ]);
+              node.body.unshift(initNode);
+            }
+          },
+        },
+      },
+    };
+  };
+}
+
+/**
+ * Build function for ember-cli-htmlbars parallelBabel.
+ * Called by setupPlugins in worker threads to reconstruct the AST plugin wrapper.
+ * Must return an object with { plugin, name } matching the wrapper format
+ * that setupPlugins expects (NOT a bare function).
+ */
+function buildForParallel(params) {
+  return {
+    plugin: createTemplateCoveragePlugin(params),
+    name: 'ember-cli-code-coverage-template',
+  };
+}
+
+module.exports = createTemplateCoveragePlugin;
+module.exports.createTemplateCoveragePlugin = createTemplateCoveragePlugin;
+module.exports.buildForParallel = buildForParallel;

--- a/packages/ember-cli-code-coverage/package.json
+++ b/packages/ember-cli-code-coverage/package.json
@@ -41,8 +41,8 @@
     "fs-extra": "^9.0.0",
     "istanbul-lib-coverage": "^3.2.2",
     "istanbul-lib-report": "^3.0.1",
-    "istanbul-reports": "^3.1.7",
     "istanbul-lib-source-maps": "^4.0.1",
+    "istanbul-reports": "^3.1.7",
     "node-dir": "^0.1.17",
     "walk-sync": "^2.1.0"
   },
@@ -52,6 +52,7 @@
     "@ember/test-helpers": "^2.4.2",
     "@embroider/test-setup": "^0.43.5",
     "@glimmer/component": "^1.1.2",
+    "@glimmer/syntax": "^0.95.0",
     "@glimmer/tracking": "^1.1.2",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",

--- a/packages/ember-cli-code-coverage/pnpm-lock.yaml
+++ b/packages/ember-cli-code-coverage/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@glimmer/component':
         specifier: ^1.1.2
         version: 1.1.2(@babel/core@7.23.3)
+      '@glimmer/syntax':
+        specifier: ^0.95.0
+        version: 0.95.0
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2
@@ -926,6 +929,9 @@ packages:
   '@glimmer/interfaces@0.84.3':
     resolution: {integrity: sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==}
 
+  '@glimmer/interfaces@0.94.6':
+    resolution: {integrity: sha512-sp/1WePvB/8O+jrcUHwjboNPTKrdGicuHKA9T/lh0vkYK2qM5Xz4i25lQMQ38tEMiw7KixrjHiTUiaXRld+IwA==}
+
   '@glimmer/reference@0.65.4':
     resolution: {integrity: sha512-yuRVE4qyqrlCndDMrHKDWUbDmGDCjPzsFtlTmxxnhDMJAdQsnr2cRLITHvQRDm1tXfigVvyKnomeuYhRRbBqYQ==}
 
@@ -934,6 +940,9 @@ packages:
 
   '@glimmer/syntax@0.84.3':
     resolution: {integrity: sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==}
+
+  '@glimmer/syntax@0.95.0':
+    resolution: {integrity: sha512-W/PHdODnpONsXjbbdY9nedgIHpglMfOzncf/moLVrKIcCfeQhw2vG07Rs/YW8KeJCgJRCLkQsi+Ix7XvrurGAg==}
 
   '@glimmer/tracking@1.1.2':
     resolution: {integrity: sha512-cyV32zsHh+CnftuRX84ALZpd2rpbDrhLhJnTXn9W//QpqdRZ5rdMsxSY9fOsj0CKEc706tmEU299oNnDc0d7tA==}
@@ -947,6 +956,9 @@ packages:
   '@glimmer/util@0.84.3':
     resolution: {integrity: sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==}
 
+  '@glimmer/util@0.94.8':
+    resolution: {integrity: sha512-HfCKeZ74clF9BsPDBOqK/yRNa/ke6niXFPM6zRn9OVYw+ZAidLs7V8He/xljUHlLRL322kaZZY8XxRW7ALEwyg==}
+
   '@glimmer/validator@0.44.0':
     resolution: {integrity: sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==}
 
@@ -956,11 +968,18 @@ packages:
   '@glimmer/vm-babel-plugins@0.80.3':
     resolution: {integrity: sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==}
 
+  '@glimmer/wire-format@0.94.8':
+    resolution: {integrity: sha512-A+Cp5m6vZMAEu0Kg/YwU2dJZXyYxVJs2zI57d3CP6NctmX7FsT8WjViiRUmt5abVmMmRH5b8BUovqY6GSMAdrw==}
+
   '@handlebars/parser@1.1.0':
     resolution: {integrity: sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==}
 
   '@handlebars/parser@2.0.0':
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
+
+  '@handlebars/parser@2.2.2':
+    resolution: {integrity: sha512-n/SZW+12rwikx/f8YcSv9JCi5p9vn1Bnts9ZtVvfErG4h0gbjHI1H1ZMhVUnaOC7yzFc6PtsCKIK8XeTnL90Gw==}
+    engines: {node: ^18 || ^20 || ^22 || >=24}
 
   '@humanwhocodes/config-array@0.5.0':
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
@@ -3422,7 +3441,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -5955,6 +5974,10 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -7391,6 +7414,11 @@ snapshots:
     dependencies:
       '@simple-dom/interface': 1.4.0
 
+  '@glimmer/interfaces@0.94.6':
+    dependencies:
+      '@simple-dom/interface': 1.4.0
+      type-fest: 4.41.0
+
   '@glimmer/reference@0.65.4':
     dependencies:
       '@glimmer/env': 0.1.7
@@ -7413,6 +7441,14 @@ snapshots:
       '@handlebars/parser': 2.0.0
       simple-html-tokenizer: 0.5.11
 
+  '@glimmer/syntax@0.95.0':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+      '@glimmer/util': 0.94.8
+      '@glimmer/wire-format': 0.94.8
+      '@handlebars/parser': 2.2.2
+      simple-html-tokenizer: 0.5.11
+
   '@glimmer/tracking@1.1.2':
     dependencies:
       '@glimmer/env': 0.1.7
@@ -7432,6 +7468,10 @@ snapshots:
       '@glimmer/interfaces': 0.84.3
       '@simple-dom/interface': 1.4.0
 
+  '@glimmer/util@0.94.8':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+
   '@glimmer/validator@0.44.0': {}
 
   '@glimmer/validator@0.65.4':
@@ -7445,9 +7485,15 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
+  '@glimmer/wire-format@0.94.8':
+    dependencies:
+      '@glimmer/interfaces': 0.94.6
+
   '@handlebars/parser@1.1.0': {}
 
   '@handlebars/parser@2.0.0': {}
+
+  '@handlebars/parser@2.2.2': {}
 
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
@@ -14084,6 +14130,8 @@ snapshots:
   type-fest@0.20.2: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:

--- a/test-packages/attach-middleware-test.mjs
+++ b/test-packages/attach-middleware-test.mjs
@@ -87,4 +87,77 @@ describe('attach-middleware', () => {
     expect(adjustCoverageKey(root, join(root, '@foo/bar/test-support/foo.js'), namespaceMappings))
       .toEqual('addon-test-support/foo.js');
   });
+
+  it('adjustCoverageKey resolves module names from template coverage via namespace mappings', async () => {
+    // Template coverage entries use module names (e.g., "my-app/templates/application")
+    // as keys, not filesystem paths. The middleware must resolve these to actual files.
+    let project = new Project('my-app', '1.0.0');
+    project.files['app'] = {
+      templates: {
+        'application.hbs': '{{outlet}}',
+      },
+      components: {
+        'foo.hbs': '<div>foo</div>',
+      },
+    };
+    await project.write();
+
+    let root = project.baseDir;
+    let namespaceMappings = new Map([
+      ['my-app', join(root, 'app')],
+    ]);
+
+    // Module name "my-app/templates/application" should resolve to the .hbs file
+    let result = adjustCoverageKey(
+      root,
+      'my-app/templates/application',
+      namespaceMappings
+    );
+    expect(result).toEqual(join(root, 'app', 'templates', 'application.hbs'));
+
+    // Module name "my-app/components/foo" should resolve to the .hbs file
+    result = adjustCoverageKey(
+      root,
+      'my-app/components/foo',
+      namespaceMappings
+    );
+    expect(result).toEqual(join(root, 'app', 'components', 'foo.hbs'));
+  });
+
+  it('adjustCoverageKey resolves scoped module names from template coverage', async () => {
+    let project = new Project('@scope/my-addon', '1.0.0');
+    project.files['addon'] = {
+      templates: {
+        'main.hbs': '{{yield}}',
+      },
+    };
+    await project.write();
+
+    let root = project.baseDir;
+    let namespaceMappings = new Map([
+      ['@scope/my-addon', join(root, 'addon')],
+    ]);
+
+    let result = adjustCoverageKey(
+      root,
+      '@scope/my-addon/templates/main',
+      namespaceMappings
+    );
+    expect(result).toEqual(join(root, 'addon', 'templates', 'main.hbs'));
+  });
+
+  it('adjustCoverageKey falls back for unresolvable module names', () => {
+    let root = '/root/';
+    let namespaceMappings = new Map([
+      ['my-app', '/root/app'],
+    ]);
+
+    // Module name with unknown namespace returns as-is (monorepo fallback)
+    let result = adjustCoverageKey(
+      root,
+      'unknown-addon/templates/foo',
+      namespaceMappings
+    );
+    expect(result).toEqual('unknown-addon/templates/foo');
+  });
 });

--- a/test-packages/coverage-helpers-test.mjs
+++ b/test-packages/coverage-helpers-test.mjs
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/**
+ * Tests for the runtime coverage helpers' logic.
+ *
+ * Since the actual helpers depend on @ember/component/helper, we test
+ * the equivalent logic directly by simulating what coverageInit,
+ * coverageMark, and coverageCond do to window.__coverage__.
+ */
+
+// Simulate the core logic of coverageInit (without the Ember helper wrapper)
+function coverageInit(globalObj, filePath, branchMapJson) {
+  if (!globalObj.__coverage__) {
+    globalObj.__coverage__ = {};
+  }
+
+  let branchMap;
+  try {
+    branchMap = JSON.parse(branchMapJson);
+  } catch (e) {
+    return;
+  }
+
+  // Merge into existing entry (handles multiple <template> blocks per file)
+  if (globalObj.__coverage__[filePath]) {
+    let existing = globalObj.__coverage__[filePath];
+    if (!globalObj.__templateCoverageStmtMap__) {
+      globalObj.__templateCoverageStmtMap__ = {};
+    }
+    let branchStmtMap = globalObj.__templateCoverageStmtMap__[filePath] || {};
+    let stmtKeys = Object.keys(existing.statementMap);
+    let stmtId = stmtKeys.length > 0
+      ? Math.max.apply(null, stmtKeys.map(Number)) + 1
+      : 0;
+
+    let ids = Object.keys(branchMap);
+    for (let i = 0; i < ids.length; i++) {
+      let id = ids[i];
+      if (existing.branchMap[id]) {
+        continue;
+      }
+      let branch = branchMap[id];
+      existing.branchMap[id] = branch;
+      existing.b[id] = branch.locations.map(function () {
+        return 0;
+      });
+      for (let j = 0; j < branch.locations.length; j++) {
+        branchStmtMap[id + ':' + j] = stmtId;
+        existing.statementMap[stmtId] = branch.locations[j];
+        existing.s[stmtId] = 0;
+        stmtId++;
+      }
+    }
+    globalObj.__templateCoverageStmtMap__[filePath] = branchStmtMap;
+    return;
+  }
+
+  // First template — create entry
+  let b = {};
+  let statementMap = {};
+  let s = {};
+  let branchStmtMap = {};
+  let stmtId = 0;
+  let ids = Object.keys(branchMap);
+  for (let i = 0; i < ids.length; i++) {
+    let id = ids[i];
+    let branch = branchMap[id];
+    b[id] = branch.locations.map(function () {
+      return 0;
+    });
+    for (let j = 0; j < branch.locations.length; j++) {
+      branchStmtMap[id + ':' + j] = stmtId;
+      statementMap[stmtId] = branch.locations[j];
+      s[stmtId] = 0;
+      stmtId++;
+    }
+  }
+
+  globalObj.__coverage__[filePath] = {
+    path: filePath,
+    statementMap: statementMap,
+    s: s,
+    branchMap: branchMap,
+    b: b,
+    fnMap: {},
+    f: {},
+  };
+
+  if (!globalObj.__templateCoverageStmtMap__) {
+    globalObj.__templateCoverageStmtMap__ = {};
+  }
+  globalObj.__templateCoverageStmtMap__[filePath] = branchStmtMap;
+}
+
+// Simulate recordBranchHit
+function recordBranchHit(globalObj, filePath, branchId, locationId) {
+  let coverage = globalObj.__coverage__ && globalObj.__coverage__[filePath];
+  if (!coverage || !coverage.b || !coverage.b[branchId]) {
+    return;
+  }
+
+  coverage.b[branchId][locationId] =
+    (coverage.b[branchId][locationId] || 0) + 1;
+
+  let stmtMap =
+    globalObj.__templateCoverageStmtMap__ &&
+    globalObj.__templateCoverageStmtMap__[filePath];
+  let stmtKey = stmtMap && stmtMap[branchId + ':' + locationId];
+  if (stmtKey !== undefined && coverage.s) {
+    coverage.s[stmtKey] = (coverage.s[stmtKey] || 0) + 1;
+  }
+}
+
+function loc(line, col) {
+  return { start: { line, column: col }, end: { line, column: col + 5 } };
+}
+
+describe('coverage-init merge behavior', function () {
+  let globalObj;
+
+  beforeEach(function () {
+    globalObj = {};
+  });
+
+  it('creates a new coverage entry for the first template', function () {
+    const branchMap = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.hbs', JSON.stringify(branchMap));
+
+    const coverage = globalObj.__coverage__['my-file.hbs'];
+    expect(coverage).toBeTruthy();
+    expect(coverage.path).toBe('my-file.hbs');
+    expect(coverage.branchMap).toHaveProperty('0');
+    expect(coverage.b['0']).toEqual([0, 0]);
+    expect(Object.keys(coverage.statementMap)).toHaveLength(2);
+    expect(coverage.s[0]).toBe(0);
+    expect(coverage.s[1]).toBe(0);
+  });
+
+  it('merges branches from second template into existing entry', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+    const branchMap2 = {
+      '1': { type: 'if', locations: [loc(5, 0), loc(5, 10)], loc: loc(5, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap2));
+
+    const coverage = globalObj.__coverage__['my-file.gts'];
+
+    // Should have both branches
+    expect(coverage.branchMap).toHaveProperty('0');
+    expect(coverage.branchMap).toHaveProperty('1');
+    expect(coverage.b['0']).toEqual([0, 0]);
+    expect(coverage.b['1']).toEqual([0, 0]);
+
+    // Should have 4 synthetic statements (2 per branch)
+    expect(Object.keys(coverage.statementMap)).toHaveLength(4);
+  });
+
+  it('does not duplicate branches on re-render (same branchIds)', function () {
+    const branchMap = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.hbs', JSON.stringify(branchMap));
+    coverageInit(globalObj, 'my-file.hbs', JSON.stringify(branchMap));
+
+    const coverage = globalObj.__coverage__['my-file.hbs'];
+    expect(Object.keys(coverage.branchMap)).toEqual(['0']);
+    expect(Object.keys(coverage.statementMap)).toHaveLength(2);
+  });
+
+  it('merges three templates correctly', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+    const branchMap2 = {
+      '1': { type: 'if', locations: [loc(5, 0), loc(5, 10)], loc: loc(5, 0) },
+      '2': { type: 'cond', locations: [loc(6, 0), loc(6, 10)], loc: loc(6, 0) },
+    };
+    const branchMap3 = {
+      '3': { type: 'if', locations: [loc(10, 0), loc(10, 10)], loc: loc(10, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap2));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap3));
+
+    const coverage = globalObj.__coverage__['my-file.gts'];
+    expect(Object.keys(coverage.branchMap).sort()).toEqual(['0', '1', '2', '3']);
+    expect(Object.keys(coverage.b).sort()).toEqual(['0', '1', '2', '3']);
+    // 4 branches × 2 locations each = 8 statements
+    expect(Object.keys(coverage.statementMap)).toHaveLength(8);
+  });
+
+  it('statement map IDs do not collide after merge', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+    const branchMap2 = {
+      '1': { type: 'if', locations: [loc(5, 0), loc(5, 10)], loc: loc(5, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap2));
+
+    const stmtMap = globalObj.__templateCoverageStmtMap__['my-file.gts'];
+
+    // Branch 0 locations map to statements 0, 1
+    expect(stmtMap['0:0']).toBe(0);
+    expect(stmtMap['0:1']).toBe(1);
+
+    // Branch 1 locations map to statements 2, 3 (no collision)
+    expect(stmtMap['1:0']).toBe(2);
+    expect(stmtMap['1:1']).toBe(3);
+  });
+});
+
+describe('recordBranchHit with merged coverage', function () {
+  let globalObj;
+
+  beforeEach(function () {
+    globalObj = {};
+  });
+
+  it('records hits for branches from both templates', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+    const branchMap2 = {
+      '1': { type: 'if', locations: [loc(5, 0), loc(5, 10)], loc: loc(5, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap2));
+
+    // Hit branch 0 (from template 1)
+    recordBranchHit(globalObj, 'my-file.gts', 0, 0);
+    // Hit branch 1 (from template 2)
+    recordBranchHit(globalObj, 'my-file.gts', 1, 1);
+
+    const coverage = globalObj.__coverage__['my-file.gts'];
+    expect(coverage.b['0']).toEqual([1, 0]);
+    expect(coverage.b['1']).toEqual([0, 1]);
+  });
+
+  it('updates synthetic statements for merged branches', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+    const branchMap2 = {
+      '1': { type: 'if', locations: [loc(5, 0), loc(5, 10)], loc: loc(5, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap2));
+
+    recordBranchHit(globalObj, 'my-file.gts', 1, 0);
+
+    const coverage = globalObj.__coverage__['my-file.gts'];
+    // Statement 2 corresponds to branch 1, location 0
+    expect(coverage.s[2]).toBe(1);
+    // Other statements unchanged
+    expect(coverage.s[0]).toBe(0);
+    expect(coverage.s[1]).toBe(0);
+    expect(coverage.s[3]).toBe(0);
+  });
+
+  it('does not crash when hitting a non-existent branch', function () {
+    const branchMap1 = {
+      '0': { type: 'if', locations: [loc(1, 0), loc(1, 10)], loc: loc(1, 0) },
+    };
+
+    coverageInit(globalObj, 'my-file.gts', JSON.stringify(branchMap1));
+
+    // Branch 99 doesn't exist — should silently no-op
+    recordBranchHit(globalObj, 'my-file.gts', 99, 0);
+
+    const coverage = globalObj.__coverage__['my-file.gts'];
+    expect(coverage.b['0']).toEqual([0, 0]);
+  });
+});

--- a/test-packages/template-coverage-import-plugin-test.mjs
+++ b/test-packages/template-coverage-import-plugin-test.mjs
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import babel from '@babel/core';
+import templateCoverageImportPlugin from '../packages/ember-cli-code-coverage/lib/template-coverage-import-plugin.js';
+
+function transformCode(code, filename = 'test.gjs') {
+  const result = babel.transformSync(code, {
+    filename,
+    plugins: [templateCoverageImportPlugin],
+  });
+  return result.code;
+}
+
+describe('template-coverage-import-plugin', function () {
+  it('adds all 3 coverage helper imports to .gjs files with template import', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.gjs');
+
+    expect(result).toContain(
+      'import coverageInit from "ember-cli-code-coverage/helpers/coverage-init"'
+    );
+    expect(result).toContain(
+      'import coverageMark from "ember-cli-code-coverage/helpers/coverage-mark"'
+    );
+    expect(result).toContain(
+      'import coverageCond from "ember-cli-code-coverage/helpers/coverage-cond"'
+    );
+  });
+
+  it('adds all 3 coverage helper imports to .gts files', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.gts');
+
+    expect(result).toContain(
+      'import coverageInit from "ember-cli-code-coverage/helpers/coverage-init"'
+    );
+    expect(result).toContain(
+      'import coverageMark from "ember-cli-code-coverage/helpers/coverage-mark"'
+    );
+    expect(result).toContain(
+      'import coverageCond from "ember-cli-code-coverage/helpers/coverage-cond"'
+    );
+  });
+
+  it('does not add imports to files without template import', function () {
+    const input = [
+      'import something from "somewhere";',
+      'const x = something();',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.js');
+
+    expect(result).not.toContain('coverage-init');
+    expect(result).not.toContain('coverage-mark');
+    expect(result).not.toContain('coverage-cond');
+  });
+
+  it('adds coverage helper imports to .ts files with template import', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.ts');
+
+    expect(result).toContain(
+      'import coverageInit from "ember-cli-code-coverage/helpers/coverage-init"'
+    );
+    expect(result).toContain(
+      'import coverageMark from "ember-cli-code-coverage/helpers/coverage-mark"'
+    );
+    expect(result).toContain(
+      'import coverageCond from "ember-cli-code-coverage/helpers/coverage-cond"'
+    );
+  });
+
+  it('adds coverage helper imports to .js files with template import', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.js');
+
+    expect(result).toContain(
+      'import coverageInit from "ember-cli-code-coverage/helpers/coverage-init"'
+    );
+  });
+
+  it('does not add imports to .gjs files without template import', function () {
+    const input = [
+      'import { on } from "@ember/modifier";',
+      'export default function foo() {}',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.gjs');
+
+    expect(result).not.toContain('coverage-init');
+    expect(result).not.toContain('coverage-mark');
+    expect(result).not.toContain('coverage-cond');
+  });
+
+  it('does not duplicate imports if already present', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'import coverageInit from "ember-cli-code-coverage/helpers/coverage-init";',
+      'import coverageMark from "ember-cli-code-coverage/helpers/coverage-mark";',
+      'import coverageCond from "ember-cli-code-coverage/helpers/coverage-cond";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.gjs');
+
+    // Count occurrences - should only have one of each
+    const initCount = (
+      result.match(/ember-cli-code-coverage\/helpers\/coverage-init/g) || []
+    ).length;
+    const markCount = (
+      result.match(/ember-cli-code-coverage\/helpers\/coverage-mark/g) || []
+    ).length;
+    const condCount = (
+      result.match(/ember-cli-code-coverage\/helpers\/coverage-cond/g) || []
+    ).length;
+
+    expect(initCount).toBe(1);
+    expect(markCount).toBe(1);
+    expect(condCount).toBe(1);
+  });
+
+  it('inserts imports after existing imports', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'import { on } from "@ember/modifier";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    const result = transformCode(input, 'test.gjs');
+
+    // The coverage imports should appear after the existing imports
+    const templateImportIdx = result.indexOf('@ember/template-compiler');
+    const modifierImportIdx = result.indexOf('@ember/modifier');
+    const coverageInitIdx = result.indexOf('coverage-init');
+    const coverageMarkIdx = result.indexOf('coverage-mark');
+    const coverageCondIdx = result.indexOf('coverage-cond');
+
+    expect(coverageInitIdx).toBeGreaterThan(templateImportIdx);
+    expect(coverageInitIdx).toBeGreaterThan(modifierImportIdx);
+    expect(coverageMarkIdx).toBeGreaterThan(templateImportIdx);
+    expect(coverageCondIdx).toBeGreaterThan(templateImportIdx);
+    expect(coverageCondIdx).toBeGreaterThan(modifierImportIdx);
+  });
+
+  it('works with source maps present (any file with template import)', function () {
+    const input = [
+      'import { template } from "@ember/template-compiler";',
+      'const Foo = template("hello", { eval() { return eval(arguments[0]); } });',
+    ].join('\n');
+
+    // Even with source maps, the plugin detects via the template import
+    const result = babel.transformSync(input, {
+      filename: 'test.js',
+      plugins: [templateCoverageImportPlugin],
+      inputSourceMap: {
+        version: 3,
+        sources: ['test.gjs'],
+        mappings: '',
+      },
+    });
+
+    expect(result.code).toContain('coverage-init');
+    expect(result.code).toContain('coverage-mark');
+    expect(result.code).toContain('coverage-cond');
+  });
+});

--- a/test-packages/template-coverage-plugin-test.mjs
+++ b/test-packages/template-coverage-plugin-test.mjs
@@ -1,0 +1,1530 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+import createTemplateCoveragePlugin from '../packages/ember-cli-code-coverage/lib/template-coverage-plugin.js';
+
+const require = createRequire(import.meta.url);
+
+// Resolve @glimmer/syntax from the addon package where it's installed
+const glimmerPath = require.resolve('@glimmer/syntax', {
+  paths: [
+    new URL('../packages/ember-cli-code-coverage', import.meta.url).pathname,
+  ],
+});
+const { preprocess, print } = require(glimmerPath);
+
+function transform(template, moduleName = 'test-app/templates/test') {
+  const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+  return transformWithPlugin(plugin, template, moduleName);
+}
+
+/**
+ * Transform a template using an existing plugin instance.
+ * Useful for testing multiple <template> blocks that share the same module
+ * (simulates .gts files with multiple templates).
+ */
+function transformWithPlugin(plugin, template, moduleName = 'test-app/templates/test') {
+  const ast = preprocess(template, {
+    mode: 'codemod',
+    plugins: {
+      ast: [
+        function (env) {
+          // Inject a custom moduleName into env.meta
+          env.meta = env.meta || {};
+          env.meta.moduleName = moduleName;
+          return plugin(env);
+        },
+      ],
+    },
+    meta: { moduleName },
+  });
+  return print(ast);
+}
+
+/**
+ * Extract the branchMap JSON from a transformed template string.
+ * The coverageInit call looks like: {{coverageInit "moduleName" "{\"0\":{...}}"}}
+ * We need to extract the second string argument which contains escaped JSON.
+ */
+function extractBranchMap(result) {
+  // Match the second quoted argument of coverageInit, handling escaped quotes
+  const initMatch = result.match(
+    /coverageInit "[^"]*" "((?:[^"\\]|\\.)*)"/
+  );
+  if (!initMatch) return null;
+  // Unescape the JSON string (\\\" -> \", \\\\ -> \\)
+  const jsonStr = initMatch[1].replace(/\\(.)/g, '$1');
+  return JSON.parse(jsonStr);
+}
+
+describe('template-coverage-plugin', function () {
+  let originalCoverage;
+
+  beforeEach(function () {
+    originalCoverage = process.env.COVERAGE;
+    process.env.COVERAGE = 'true';
+  });
+
+  afterEach(function () {
+    if (originalCoverage === undefined) {
+      delete process.env.COVERAGE;
+    } else {
+      process.env.COVERAGE = originalCoverage;
+    }
+  });
+
+  describe('when COVERAGE is not enabled', function () {
+    it('does not instrument templates', function () {
+      process.env.COVERAGE = 'false';
+
+      const input = '{{#if condition}}yes{{/if}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+  });
+
+  describe('{{#if}} blocks', function () {
+    it('instruments a simple if block', function () {
+      const input = '{{#if condition}}yes{{/if}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageMark');
+      // Should have the module name
+      expect(result).toContain('test-app/templates/test');
+    });
+
+    it('instruments if/else blocks', function () {
+      const input = '{{#if condition}}yes{{else}}no{{/if}}';
+      const result = transform(input);
+
+      // Should have coverageInit at the start
+      expect(result).toContain('coverageInit');
+      // Should have coverageMark in both branches
+      // Branch 0, location 0 (consequent)
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      // Branch 0, location 1 (alternate)
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+    });
+
+    it('instruments chained else-if blocks', function () {
+      const input =
+        '{{#if a}}first{{else if b}}second{{else}}third{{/if}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      // First if: branch 0
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+      // Inner if: branch 1
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 1 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 1 1}}'
+      );
+    });
+
+    it('handles if block without else (no implicit else location)', function () {
+      const input = '{{#if condition}}yes{{/if}}';
+      const result = transform(input);
+
+      // Should have coverageMark for the consequent
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      // Should NOT have coverageMark for an implicit else
+      expect(result).not.toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+
+      // branchMap should have only 1 location (the if-body).
+      // Absent {{else}} is treated as always-visited empty content,
+      // so Istanbul won't report "else path not taken".
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].locations).toHaveLength(1);
+    });
+
+    it('if/else still has 2 locations', function () {
+      const input = '{{#if condition}}yes{{else}}no{{/if}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+  });
+
+  describe('{{#unless}} blocks', function () {
+    it('instruments unless blocks', function () {
+      const input = '{{#unless condition}}no{{/unless}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+    });
+
+    it('instruments unless/else blocks', function () {
+      const input = '{{#unless condition}}no{{else}}yes{{/unless}}';
+      const result = transform(input);
+
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+    });
+  });
+
+  describe('{{#each}} blocks', function () {
+    it('does not instrument each without else', function () {
+      const input = '{{#each items as |item|}}{{item}}{{/each}}';
+      const result = transform(input);
+
+      // No branches, so no coverage-init or coverage-mark
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+    });
+
+    it('instruments each/else blocks', function () {
+      const input =
+        '{{#each items as |item|}}{{item}}{{else}}empty{{/each}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      // Branch 0, location 0 (items exist)
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      // Branch 0, location 1 (empty list)
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+    });
+  });
+
+  describe('{{#each-in}} blocks', function () {
+    it('instruments each-in/else blocks', function () {
+      const input =
+        '{{#each-in obj as |key val|}}{{key}}{{else}}empty{{/each-in}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+    });
+  });
+
+  describe('non-branching blocks', function () {
+    it('does not instrument {{#let}} blocks', function () {
+      const input = '{{#let (hash a=1) as |h|}}{{h.a}}{{/let}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+    });
+
+    it('does not instrument {{#in-element}} blocks', function () {
+      const input = '{{#in-element this.target}}content{{/in-element}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+    });
+
+    it('does not instrument {{#-in-element}} blocks', function () {
+      const input = '{{#-in-element this.target}}content{{/-in-element}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+    });
+  });
+
+  describe('multiple branches in one template', function () {
+    it('assigns unique branch IDs', function () {
+      const input = [
+        '{{#if a}}first{{else}}second{{/if}}',
+        '{{#if b}}third{{else}}fourth{{/if}}',
+      ].join('\n');
+      const result = transform(input);
+
+      // First if: branch 0
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+      // Second if: branch 1
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 1 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 1 1}}'
+      );
+    });
+  });
+
+  describe('nested branches', function () {
+    it('instruments all nested levels', function () {
+      const input = [
+        '{{#if a}}',
+        '  {{#if b}}inner-yes{{else}}inner-no{{/if}}',
+        '{{else}}',
+        '  outer-no',
+        '{{/if}}',
+      ].join('\n');
+      const result = transform(input);
+
+      // Outer if: one branch
+      // Inner if: another branch
+      expect(result).toContain('coverageInit');
+
+      // We should have marks for both branches (exact IDs depend on visit order)
+      const markCount = (result.match(/coverageMark/g) || []).length;
+      // outer: 2 (consequent + alternate) + inner: 2 (consequent + alternate)
+      expect(markCount).toBe(4);
+    });
+  });
+
+  describe('coverageInit branchMap format', function () {
+    it('produces valid Istanbul-compatible branchMap JSON', function () {
+      const input = '{{#if cond}}yes{{else}}no{{/if}}';
+      const result = transform(input);
+
+      // Extract the branchMap JSON from the coverageInit call
+      const branchMap = extractBranchMap(result);
+
+      expect(branchMap).toHaveProperty('0');
+      expect(branchMap['0']).toHaveProperty('type', 'if');
+      expect(branchMap['0']).toHaveProperty('locations');
+      expect(branchMap['0'].locations).toHaveLength(2);
+      expect(branchMap['0']).toHaveProperty('loc');
+      expect(branchMap['0'].loc).toHaveProperty('start');
+      expect(branchMap['0'].loc).toHaveProperty('end');
+
+      // Each location should have start and end
+      for (const loc of branchMap['0'].locations) {
+        expect(loc).toHaveProperty('start');
+        expect(loc.start).toHaveProperty('line');
+        expect(loc.start).toHaveProperty('column');
+        expect(loc).toHaveProperty('end');
+      }
+    });
+  });
+
+  describe('custom module names', function () {
+    it('uses the provided module name', function () {
+      const input = '{{#if cond}}yes{{/if}}';
+      const result = transform(input, 'my-addon/components/fancy');
+
+      expect(result).toContain('my-addon/components/fancy');
+    });
+  });
+
+  describe('custom coverage env var', function () {
+    it('respects custom env var name', function () {
+      delete process.env.COVERAGE;
+      process.env.MY_COV = 'true';
+
+      const plugin = createTemplateCoveragePlugin({
+        coverageEnvVar: 'MY_COV',
+      });
+      const ast = preprocess('{{#if cond}}yes{{/if}}', {
+        mode: 'codemod',
+        plugins: {
+          ast: [
+            function (env) {
+              env.meta = { moduleName: 'test' };
+              return plugin(env);
+            },
+          ],
+        },
+        meta: { moduleName: 'test' },
+      });
+      const result = print(ast);
+
+      expect(result).toContain('coverageMark');
+
+      delete process.env.MY_COV;
+    });
+  });
+
+  describe('plain template without branches', function () {
+    it('does not instrument a template with no conditionals', function () {
+      const input = '<div>Hello</div>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageCond');
+    });
+  });
+
+  describe('inline {{if}} MustacheStatement', function () {
+    it('instruments inline {{if condition "yes" "no"}}', function () {
+      const input = '<div>{{if condition "yes" "no"}}</div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+      // Should wrap the condition with coverageCond
+      expect(result).toContain('test-app/templates/test');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0']).toBeTruthy();
+      expect(branchMap['0'].type).toBe('cond');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('instruments inline {{unless condition "no"}}', function () {
+      const input = '<div>{{unless condition "fallback"}}</div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('cond');
+    });
+
+    it('does not instrument {{if}} with only 1 param (just condition)', function () {
+      // {{if condition}} with no trueVal is not a valid inline conditional to instrument
+      // The plugin requires at least 2 params
+      const input = '<div>{{if condition}}</div>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageCond');
+    });
+  });
+
+  describe('inline (if) SubExpression', function () {
+    it('instruments inline (if condition "yes" "no") in SubExpression position', function () {
+      const input = '<div class={{if isActive "active" "inactive"}}></div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('cond');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('instruments inline (unless condition "no" "yes") with both branches', function () {
+      const input = '<div class={{unless isHidden "visible" "hidden"}}></div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('cond');
+    });
+
+    it('instruments (if condition "yes") without falseVal (2 params)', function () {
+      const input = '<div class={{if isActive "active"}}></div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('cond');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('does not instrument (if) with only 1 param (just condition)', function () {
+      // (if condition) with no trueVal should NOT be instrumented
+      // This is a SubExpression with only 1 param
+      const input = '{{someHelper (if condition)}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageCond');
+    });
+  });
+
+  describe('coverageCond wrapping behavior', function () {
+    it('wraps condition with reversed=false for inline if', function () {
+      const input = '<div class={{if isActive "active" "inactive"}}></div>';
+      const result = transform(input);
+
+      // For `if`, reversed should be false
+      expect(result).toContain('coverageCond');
+      // The output should contain the coverageCond call with false for reversed
+      expect(result).toMatch(/coverageCond\s+"[^"]+"\s+0\s+false/);
+    });
+
+    it('wraps condition with reversed=true for inline unless', function () {
+      const input = '<div class={{unless isHidden "visible" "hidden"}}></div>';
+      const result = transform(input);
+
+      // For `unless`, reversed should be true
+      expect(result).toContain('coverageCond');
+      expect(result).toMatch(/coverageCond\s+"[^"]+"\s+0\s+true/);
+    });
+  });
+
+  describe('inline conditional branchMap type vs block branchMap type', function () {
+    it('uses type "cond" for inline conditionals', function () {
+      const input = '<div>{{if cond "a" "b"}}</div>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap['0'].type).toBe('cond');
+    });
+
+    it('uses type "if" for block if', function () {
+      const input = '{{#if cond}}yes{{else}}no{{/if}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap['0'].type).toBe('if');
+    });
+
+    it('uses type "unless" for block unless', function () {
+      const input = '{{#unless cond}}no{{else}}yes{{/unless}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap['0'].type).toBe('unless');
+    });
+
+    it('uses type "each" for each/else blocks', function () {
+      const input = '{{#each items as |item|}}{{item}}{{else}}empty{{/each}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap['0'].type).toBe('each');
+    });
+  });
+
+  describe('template with ONLY inline conditionals (no blocks)', function () {
+    it('still gets coverageInit injected', function () {
+      const input = '<div class={{if isActive "active" "inactive"}}>{{unless isHidden "show"}}</div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      // Should NOT contain coverageMark (no block branches)
+      expect(result).not.toContain('coverageMark');
+      // Should contain coverageCond for the inline conditionals
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      // Two inline conditionals -> two branches
+      expect(Object.keys(branchMap)).toHaveLength(2);
+      expect(branchMap['0'].type).toBe('cond');
+      expect(branchMap['1'].type).toBe('cond');
+    });
+  });
+
+  describe('mixed block + inline conditionals', function () {
+    it('assigns unique branch IDs across block and inline conditionals', function () {
+      const input = [
+        '{{#if blockCond}}yes{{else}}no{{/if}}',
+        '<div class={{if inlineCond "a" "b"}}></div>',
+      ].join('\n');
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageMark');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      // Branch 0 = block if, branch 1 = inline if
+      expect(Object.keys(branchMap)).toHaveLength(2);
+      expect(branchMap['0'].type).toBe('if');
+      expect(branchMap['1'].type).toBe('cond');
+    });
+  });
+
+  describe('deeply nested inline conditionals', function () {
+    it('instruments nested inline conditionals', function () {
+      // (if a (if b "deep-yes" "deep-no") "outer-no")
+      const input = '<div class={{if a (if b "deep-yes" "deep-no") "outer-no"}}></div>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageCond');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      // Two inline conditionals: outer (if a ...) and inner (if b ...)
+      expect(Object.keys(branchMap)).toHaveLength(2);
+      expect(branchMap['0'].type).toBe('cond');
+      expect(branchMap['1'].type).toBe('cond');
+    });
+
+    it('instruments triple-nested inline conditionals', function () {
+      const input = '<div>{{if a (if b (if c "deep" "c-no") "b-no") "a-no"}}</div>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(Object.keys(branchMap)).toHaveLength(3);
+      // All should be type "cond"
+      for (const key of Object.keys(branchMap)) {
+        expect(branchMap[key].type).toBe('cond');
+      }
+    });
+  });
+
+  describe('when COVERAGE is not enabled - inline conditionals', function () {
+    it('does not instrument inline conditionals', function () {
+      process.env.COVERAGE = 'false';
+
+      const input = '<div class={{if cond "a" "b"}}></div>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageCond');
+      expect(result).not.toContain('coverageInit');
+    });
+  });
+
+  describe('inline conditional location accuracy', function () {
+    it('points locations[0] at the trueVal and locations[1] at the falseVal for {{if isActive "on" "off"}}', function () {
+      const input = '{{if isActive "on" "off"}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      const branch = branchMap['0'];
+      expect(branch.type).toBe('cond');
+      expect(branch.locations).toHaveLength(2);
+
+      // locations[0] should point to "on" (the consequent value param)
+      const onLoc = branch.locations[0];
+      expect(onLoc.start.line).toBe(1);
+      expect(onLoc.start.column).toBe(14);
+      expect(onLoc.end.line).toBe(1);
+      expect(onLoc.end.column).toBe(18);
+
+      // locations[1] should point to "off" (the alternate value param)
+      const offLoc = branch.locations[1];
+      expect(offLoc.start.line).toBe(1);
+      expect(offLoc.start.column).toBe(19);
+      expect(offLoc.end.line).toBe(1);
+      expect(offLoc.end.column).toBe(24);
+    });
+
+    it('uses a zero-width span at end of expression for missing falseVal in {{if isActive "on"}}', function () {
+      const input = '{{if isActive "on"}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      const branch = branchMap['0'];
+      expect(branch.type).toBe('cond');
+      expect(branch.locations).toHaveLength(2);
+
+      // locations[0] should point to "on"
+      const onLoc = branch.locations[0];
+      expect(onLoc.start.line).toBe(1);
+      expect(onLoc.start.column).toBe(14);
+      expect(onLoc.end.line).toBe(1);
+      expect(onLoc.end.column).toBe(18);
+
+      // locations[1] should be a zero-width span at the end of the whole expression
+      const implicitLoc = branch.locations[1];
+      expect(implicitLoc.start.line).toBe(implicitLoc.end.line);
+      expect(implicitLoc.start.column).toBe(implicitLoc.end.column);
+      // Should be at the end of the node (end of "{{if isActive "on"}}")
+      expect(implicitLoc.start.line).toBe(branch.loc.end.line);
+      expect(implicitLoc.start.column).toBe(branch.loc.end.column);
+    });
+  });
+
+  describe('block conditional location accuracy', function () {
+    it('points branchMap locations at program/inverse bodies for multi-line block', function () {
+      const input = '{{#if cond}}\n  yes\n{{else}}\n  no\n{{/if}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      const branch = branchMap['0'];
+      expect(branch.type).toBe('if');
+      expect(branch.locations).toHaveLength(2);
+
+      // locations[0] = the program body (consequent), should start after {{#if cond}}
+      const programLoc = branch.locations[0];
+      // The program body starts on line 1 (after the opening tag) and ends at line 3
+      expect(programLoc.start.line).toBeGreaterThanOrEqual(1);
+      expect(programLoc.end.line).toBeGreaterThanOrEqual(2);
+      // Program loc should NOT be the same as the whole node loc
+      // (it should be the body, not the entire {{#if}}...{{/if}})
+      expect(programLoc).not.toEqual(branch.loc);
+
+      // locations[1] = the inverse body (alternate), should point to the else block
+      const inverseLoc = branch.locations[1];
+      expect(inverseLoc.start.line).toBeGreaterThanOrEqual(3);
+      expect(inverseLoc.end.line).toBeGreaterThanOrEqual(4);
+      expect(inverseLoc).not.toEqual(branch.loc);
+    });
+  });
+
+  describe('statementMap generation from branchMap', function () {
+    it('builds statementMap entries matching branch locations (simulating coverage-init)', function () {
+      const input = [
+        '{{#if a}}yes{{else}}no{{/if}}',
+        '<div>{{if b "x" "y"}}</div>',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+
+      // Simulate what coverage-init does: build statementMap from branchMap
+      let statementMap = {};
+      let s = {};
+      let b = {};
+      let branchStmtMap = {};
+      let stmtId = 0;
+      let ids = Object.keys(branchMap);
+      for (let i = 0; i < ids.length; i++) {
+        let id = ids[i];
+        let branch = branchMap[id];
+        b[id] = branch.locations.map(function () {
+          return 0;
+        });
+        for (let j = 0; j < branch.locations.length; j++) {
+          branchStmtMap[id + ':' + j] = stmtId;
+          statementMap[stmtId] = branch.locations[j];
+          s[stmtId] = 0;
+          stmtId++;
+        }
+      }
+
+      // Two branches, each with 2 locations = 4 synthetic statements
+      expect(Object.keys(statementMap)).toHaveLength(4);
+      expect(Object.keys(s)).toHaveLength(4);
+
+      // Each statement counter starts at 0
+      for (const key of Object.keys(s)) {
+        expect(s[key]).toBe(0);
+      }
+
+      // Each statement location matches a branch location
+      // Branch 0 (block if): locations[0] -> stmt 0, locations[1] -> stmt 1
+      expect(statementMap[0]).toEqual(branchMap['0'].locations[0]);
+      expect(statementMap[1]).toEqual(branchMap['0'].locations[1]);
+      // Branch 1 (inline if): locations[0] -> stmt 2, locations[1] -> stmt 3
+      expect(statementMap[2]).toEqual(branchMap['1'].locations[0]);
+      expect(statementMap[3]).toEqual(branchMap['1'].locations[1]);
+
+      // branchStmtMap maps "branchId:locationId" -> stmtId
+      expect(branchStmtMap['0:0']).toBe(0);
+      expect(branchStmtMap['0:1']).toBe(1);
+      expect(branchStmtMap['1:0']).toBe(2);
+      expect(branchStmtMap['1:1']).toBe(3);
+
+      // Branch counters initialized to zeros with correct length
+      expect(b['0']).toEqual([0, 0]);
+      expect(b['1']).toEqual([0, 0]);
+    });
+  });
+
+  describe('buildTemplateCoveragePlugin method', function () {
+    let buildTemplateCoveragePlugin;
+
+    beforeEach(async function () {
+      // Dynamically require index.js to access buildTemplateCoveragePlugin
+      const require = createRequire(import.meta.url);
+      const indexPath = new URL(
+        '../packages/ember-cli-code-coverage/index.js',
+        import.meta.url
+      ).pathname;
+      // Clear the require cache so env changes take effect
+      delete require.cache[require.resolve(indexPath)];
+      const addon = require(indexPath);
+      buildTemplateCoveragePlugin = addon.buildTemplateCoveragePlugin;
+    });
+
+    it('returns an empty array when COVERAGE is not "true"', function () {
+      process.env.COVERAGE = 'false';
+
+      const result = buildTemplateCoveragePlugin();
+      expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when COVERAGE is undefined', function () {
+      delete process.env.COVERAGE;
+
+      const result = buildTemplateCoveragePlugin();
+      expect(result).toEqual([]);
+    });
+
+    it('returns an array with a plugin function when COVERAGE is "true"', function () {
+      process.env.COVERAGE = 'true';
+
+      const result = buildTemplateCoveragePlugin();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(typeof result[0]).toBe('function');
+    });
+
+    it('respects a custom coverageEnvVar option', function () {
+      delete process.env.COVERAGE;
+      process.env.MY_CUSTOM_COV = 'true';
+
+      const result = buildTemplateCoveragePlugin({
+        coverageEnvVar: 'MY_CUSTOM_COV',
+      });
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(typeof result[0]).toBe('function');
+
+      delete process.env.MY_CUSTOM_COV;
+    });
+
+    it('returns empty array for custom env var when that var is not "true"', function () {
+      delete process.env.COVERAGE;
+      process.env.MY_CUSTOM_COV = 'false';
+
+      const result = buildTemplateCoveragePlugin({
+        coverageEnvVar: 'MY_CUSTOM_COV',
+      });
+      expect(result).toEqual([]);
+
+      delete process.env.MY_CUSTOM_COV;
+    });
+  });
+
+  describe('mixed inline + block with correct location types', function () {
+    it('block locations point to program/inverse bodies while inline locations point to value params', function () {
+      const input = [
+        '{{#if blockCond}}',
+        '  block-yes',
+        '{{else}}',
+        '  block-no',
+        '{{/if}}',
+        '<div class={{if inlineCond "active" "inactive"}}></div>',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(Object.keys(branchMap)).toHaveLength(2);
+
+      // Branch 0 = block if
+      const blockBranch = branchMap['0'];
+      expect(blockBranch.type).toBe('if');
+      expect(blockBranch.locations).toHaveLength(2);
+
+      // Block locations should point to program/inverse bodies, not the whole node
+      // The program body spans multiple lines (line 1-3 area)
+      const blockProgram = blockBranch.locations[0];
+      const blockInverse = blockBranch.locations[1];
+      // Program and inverse are different sections of the template
+      expect(blockProgram).not.toEqual(blockInverse);
+      // Neither should be the whole node loc
+      expect(blockProgram).not.toEqual(blockBranch.loc);
+      expect(blockInverse).not.toEqual(blockBranch.loc);
+
+      // Branch 1 = inline if
+      const inlineBranch = branchMap['1'];
+      expect(inlineBranch.type).toBe('cond');
+      expect(inlineBranch.locations).toHaveLength(2);
+
+      // Inline locations should point to the specific value params ("active" and "inactive")
+      const consequentLoc = inlineBranch.locations[0];
+      const alternateLoc = inlineBranch.locations[1];
+      // Both should be on the same line (line 6)
+      expect(consequentLoc.start.line).toBe(6);
+      expect(alternateLoc.start.line).toBe(6);
+      // The consequent comes before the alternate
+      expect(consequentLoc.start.column).toBeLessThan(
+        alternateLoc.start.column
+      );
+      // Inline locations are small spans (a single string literal), not multi-line blocks
+      expect(consequentLoc.start.line).toBe(consequentLoc.end.line);
+      expect(alternateLoc.start.line).toBe(alternateLoc.end.line);
+    });
+  });
+
+  describe('named block coverage', function () {
+    it('instruments a single named block <:default>', function () {
+      const input = '<MyComponent>\n  <:default>Default content</:default>\n</MyComponent>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageMark');
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('named-block');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('instruments multiple named blocks <:header>, <:body>, <:footer>', function () {
+      const input = [
+        '<MyComponent>',
+        '  <:header>Header content</:header>',
+        '  <:body>Body content</:body>',
+        '  <:footer>Footer content</:footer>',
+        '</MyComponent>',
+      ].join('\n');
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      // Each named block gets its own branch
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 1 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 2 0}}'
+      );
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(Object.keys(branchMap)).toHaveLength(3);
+      expect(branchMap['0'].type).toBe('named-block');
+      expect(branchMap['1'].type).toBe('named-block');
+      expect(branchMap['2'].type).toBe('named-block');
+    });
+
+    it('named block branchMap type is "named-block"', function () {
+      const input = '<MyComponent>\n  <:header>Header</:header>\n</MyComponent>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('named-block');
+    });
+
+    it('named blocks get unique branch IDs alongside other branch types', function () {
+      const input = [
+        '{{#if cond}}yes{{else}}no{{/if}}',
+        '<MyComponent>',
+        '  <:header>Header</:header>',
+        '</MyComponent>',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(Object.keys(branchMap)).toHaveLength(2);
+      // Branch 0 = if block, Branch 1 = named block
+      expect(branchMap['0'].type).toBe('if');
+      expect(branchMap['1'].type).toBe('named-block');
+    });
+
+    it('handles mixed named blocks + if/else blocks', function () {
+      const input = [
+        '<MyComponent>',
+        '  <:header>',
+        '    {{#if showTitle}}Title{{else}}No Title{{/if}}',
+        '  </:header>',
+        '  <:body>Body content</:body>',
+        '</MyComponent>',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      // Named block <:header> + if/else inside it + named block <:body>
+      expect(Object.keys(branchMap)).toHaveLength(3);
+
+      // Visitor order: ElementNode for <:header>, then BlockStatement for if/else inside,
+      // then ElementNode for <:body>
+      // The actual order depends on Glimmer's traversal; let's just check types exist
+      const types = Object.values(branchMap).map(function (b) {
+        return b.type;
+      });
+      expect(types.filter(function (t) { return t === 'named-block'; })).toHaveLength(2);
+      expect(types.filter(function (t) { return t === 'if'; })).toHaveLength(1);
+    });
+
+    it('handles empty named blocks', function () {
+      const input = '<MyComponent>\n  <:header></:header>\n</MyComponent>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageMark');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      expect(branchMap['0'].type).toBe('named-block');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('each named block has two locations (rendered + implicit not-rendered)', function () {
+      const input = [
+        '<MyComponent>',
+        '  <:header>Header</:header>',
+        '  <:body>Body</:body>',
+        '</MyComponent>',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      // Each named block branch has 2 locations (rendered + implicit not-rendered)
+      for (const key of Object.keys(branchMap)) {
+        expect(branchMap[key].type).toBe('named-block');
+        expect(branchMap[key].locations).toHaveLength(2);
+        // Location 0 (rendered) has start and end spanning the block
+        expect(branchMap[key].locations[0]).toHaveProperty('start');
+        expect(branchMap[key].locations[0]).toHaveProperty('end');
+        expect(branchMap[key].locations[0].start).toHaveProperty('line');
+        expect(branchMap[key].locations[0].start).toHaveProperty('column');
+        // Location 1 (not-rendered) is a zero-width span at the block end
+        expect(branchMap[key].locations[1].start).toEqual(
+          branchMap[key].locations[0].end
+        );
+      }
+    });
+
+    it('does not instrument regular elements (non-named-blocks)', function () {
+      const input = '<div>Hello</div><span>World</span>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageInit');
+      expect(result).not.toContain('coverageMark');
+    });
+
+    it('named block loc points to the element node location', function () {
+      const input = '<MyComponent>\n  <:header>Header content</:header>\n</MyComponent>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).toBeTruthy();
+      const branch = branchMap['0'];
+      expect(branch.loc).toHaveProperty('start');
+      expect(branch.loc).toHaveProperty('end');
+      // The loc should cover the named block element
+      expect(branch.loc.start.line).toBe(2);
+    });
+  });
+
+  describe('implicit default block coverage', function () {
+    it('instruments <MyComponent>content</MyComponent> as a default-block branch', function () {
+      const input = '<MyComponent>default content</MyComponent>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageInit');
+      expect(result).toContain('coverageMark');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0']).toBeDefined();
+      expect(branchMap['0'].type).toBe('default-block');
+      expect(branchMap['0'].locations).toHaveLength(2);
+    });
+
+    it('instruments dotted component invocations (e.g. <foo.bar>)', function () {
+      const input = '<foo.bar>some content</foo.bar>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageMark');
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+    });
+
+    it('does not instrument regular HTML elements', function () {
+      const input = '<div>hello</div>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('does not instrument self-closing components (no children)', function () {
+      const input = '<MyComponent />';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('does not instrument components with empty children', function () {
+      const input = '<MyComponent></MyComponent>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('does not instrument components whose children are all named blocks', function () {
+      const input = '<MyComponent><:header>h</:header><:body>b</:body></MyComponent>';
+      const result = transform(input);
+
+      // Named blocks themselves should be instrumented, but no default-block branch
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      const types = Object.values(branchMap).map(function (b) { return b.type; });
+      expect(types).not.toContain('default-block');
+      expect(types.filter(function (t) { return t === 'named-block'; })).toHaveLength(2);
+    });
+
+    it('instruments default block alongside other branch types', function () {
+      const input = '<MyComponent>{{#if cond}}yes{{/if}}</MyComponent>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      const types = Object.values(branchMap).map(function (b) { return b.type; });
+      expect(types).toContain('default-block');
+      expect(types).toContain('if');
+    });
+
+    it('default-block branch has 2 locations (rendered + implicit not-rendered)', function () {
+      const input = '<MyComponent>\n  Some content\n</MyComponent>';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].locations).toHaveLength(2);
+      // Second location (not-rendered) is zero-width at end of node
+      const loc0 = branchMap['0'].locations[0];
+      const loc1 = branchMap['0'].locations[1];
+      expect(loc0.start).toBeDefined();
+      expect(loc1.start).toEqual(loc1.end);
+    });
+
+    it('injects coverageMark at the beginning of component children', function () {
+      const input = '<MyComponent>hello</MyComponent>';
+      const result = transform(input);
+
+      // coverageMark should appear before the content
+      const markIdx = result.indexOf('coverageMark');
+      const contentIdx = result.indexOf('hello');
+      expect(markIdx).toBeLessThan(contentIdx);
+    });
+
+    it('detects components by @-prefixed attributes', function () {
+      const input = '<my-thing @value={{1}}>content</my-thing>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageMark');
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+    });
+
+    it('detects components by block params (as |...|)', function () {
+      const input = '<my-thing as |item|>{{item}}</my-thing>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageMark');
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+    });
+
+    it('does not instrument lowercase elements without component signals', function () {
+      const input = '<my-thing>content</my-thing>';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('instruments built-in Ember components like <LinkTo>', function () {
+      const input = '<LinkTo @route="home">Go home</LinkTo>';
+      const result = transform(input);
+
+      expect(result).toContain('coverageMark');
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+    });
+
+    it('does not instrument self-closing built-in components like <Input />', function () {
+      const input = '<Input @type="text" @value={{this.name}} />';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+    });
+  });
+
+  describe('curly component block coverage', function () {
+    it('instruments {{#my-component}}...{{/my-component}}', function () {
+      const input = '{{#my-component}}block content{{/my-component}}';
+      const result = transform(input);
+
+      expect(result).toContain('coverageMark');
+      expect(result).toContain('coverageInit');
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+    });
+
+    it('instruments {{#my-component}}...{{else}}...{{/my-component}}', function () {
+      const input =
+        '{{#my-component}}default{{else}}inverse{{/my-component}}';
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('default-block');
+      expect(branchMap['0'].locations).toHaveLength(2);
+      // Both branches instrumented
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 0}}'
+      );
+      expect(result).toContain(
+        '{{coverageMark "test-app/templates/test" 0 1}}'
+      );
+    });
+
+    it('does not instrument {{#let}} as a curly component', function () {
+      const input = '{{#let (hash a=1) as |h|}}{{h.a}}{{/let}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('does not instrument {{#with}} as a curly component', function () {
+      const input = '{{#with foo as |bar|}}{{bar}}{{/with}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('assigns unique branch IDs alongside other branch types', function () {
+      const input = [
+        '{{#if cond}}yes{{/if}}',
+        '{{#my-component}}content{{/my-component}}',
+      ].join('\n');
+      const result = transform(input);
+
+      const branchMap = extractBranchMap(result);
+      expect(branchMap).not.toBeNull();
+      expect(branchMap['0'].type).toBe('if');
+      expect(branchMap['1'].type).toBe('default-block');
+    });
+  });
+
+  describe('{{yield}} non-instrumentation', function () {
+    it('does not instrument {{yield}}', function () {
+      const input = '{{yield}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageCond');
+      expect(result).not.toContain('coverageInit');
+    });
+
+    it('does not instrument {{yield to="inverse"}}', function () {
+      const input = '{{yield to="inverse"}}';
+      const result = transform(input);
+
+      expect(result).not.toContain('coverageMark');
+      expect(result).not.toContain('coverageCond');
+      expect(result).not.toContain('coverageInit');
+    });
+  });
+
+  describe('buildBabelPlugin v8 compat mode', function () {
+    let buildBabelPlugin;
+
+    beforeEach(async function () {
+      const require = createRequire(import.meta.url);
+      const indexPath = new URL(
+        '../packages/ember-cli-code-coverage/index.js',
+        import.meta.url
+      ).pathname;
+      delete require.cache[require.resolve(indexPath)];
+      const addon = require(indexPath);
+      buildBabelPlugin = addon.buildBabelPlugin;
+    });
+
+    it('returns only the import plugin when v8: true and COVERAGE=true', function () {
+      process.env.COVERAGE = 'true';
+
+      const result = buildBabelPlugin({ v8: true });
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      // Should be the template-coverage-import-plugin path
+      expect(result[0]).toContain('template-coverage-import-plugin');
+      // Should NOT contain istanbul or gjs-gts-istanbul-ignore
+      expect(result.join(',')).not.toContain('istanbul');
+      expect(result.join(',')).not.toContain('gjs-gts-istanbul-ignore');
+    });
+
+    it('returns empty array when v8: true and COVERAGE is not true', function () {
+      process.env.COVERAGE = 'false';
+
+      const result = buildBabelPlugin({ v8: true });
+      expect(result).toEqual([]);
+    });
+
+    it('returns full plugin set (with istanbul) when v8 is not set', function () {
+      process.env.COVERAGE = 'true';
+
+      const result = buildBabelPlugin();
+
+      expect(result.length).toBeGreaterThanOrEqual(2);
+      // Should contain both the import plugin and istanbul
+      const pluginStr = result
+        .map((p) => (Array.isArray(p) ? p[0] : p))
+        .join(',');
+      expect(pluginStr).toContain('template-coverage-import-plugin');
+      expect(pluginStr).toContain('istanbul');
+    });
+
+    it('v8 mode does not include gjs-gts-istanbul-ignore plugin', function () {
+      process.env.COVERAGE = 'true';
+
+      const v8Result = buildBabelPlugin({ v8: true });
+      const pluginStr = v8Result
+        .map((p) => (Array.isArray(p) ? p[0] : p))
+        .join(',');
+      expect(pluginStr).not.toContain('gjs-gts-istanbul-ignore');
+    });
+
+    it('v8 mode works with embroider: true (v8 takes precedence)', function () {
+      process.env.COVERAGE = 'true';
+
+      const result = buildBabelPlugin({ v8: true, embroider: true });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toContain('template-coverage-import-plugin');
+    });
+  });
+
+  describe('plugins are parallelizable (broccoli-babel-transpiler compat)', function () {
+    // broccoli-babel-transpiler checks _parallelBabel on plugin functions/objects
+    // to enable parallel transpilation. Our plugins must support this.
+    function implementsParallelAPI(object) {
+      const type = typeof object;
+      const hasProperties =
+        type === 'function' ||
+        (type === 'object' && object !== null) ||
+        Array.isArray(object);
+      return (
+        hasProperties &&
+        object._parallelBabel !== null &&
+        typeof object._parallelBabel === 'object' &&
+        typeof object._parallelBabel.requireFile === 'string'
+      );
+    }
+
+    it('template-coverage-import-plugin has _parallelBabel', function () {
+      const require = createRequire(import.meta.url);
+      const plugin = require(
+        '../packages/ember-cli-code-coverage/lib/template-coverage-import-plugin.js'
+      );
+      expect(typeof plugin).toBe('function');
+      expect(implementsParallelAPI(plugin)).toBe(true);
+      expect(plugin._parallelBabel.requireFile).toContain(
+        'template-coverage-import-plugin'
+      );
+    });
+
+    it('gjs-gts-istanbul-ignore-template-plugin has _parallelBabel', function () {
+      const require = createRequire(import.meta.url);
+      const plugin = require(
+        '../packages/ember-cli-code-coverage/lib/gjs-gts-istanbul-ignore-template-plugin.js'
+      );
+      expect(typeof plugin).toBe('function');
+      expect(implementsParallelAPI(plugin)).toBe(true);
+      expect(plugin._parallelBabel.requireFile).toContain(
+        'gjs-gts-istanbul-ignore-template-plugin'
+      );
+    });
+
+    it('istanbul plugin entry has _parallelBabel on the array', function () {
+      process.env.COVERAGE = 'true';
+      const require = createRequire(import.meta.url);
+      const indexPath = new URL(
+        '../packages/ember-cli-code-coverage/index.js',
+        import.meta.url
+      ).pathname;
+      delete require.cache[require.resolve(indexPath)];
+      const addon = require(indexPath);
+      const plugins = addon.buildBabelPlugin();
+
+      // Find the istanbul entry (array with _parallelBabel)
+      const istanbulEntry = plugins.find(
+        (p) => Array.isArray(p) && p._parallelBabel
+      );
+      expect(istanbulEntry).toBeTruthy();
+      expect(implementsParallelAPI(istanbulEntry)).toBe(true);
+      expect(istanbulEntry._parallelBabel.requireFile).toContain(
+        'istanbul-plugin-wrapper'
+      );
+      expect(istanbulEntry._parallelBabel.buildUsing).toBe(
+        'buildIstanbulPlugin'
+      );
+      expect(istanbulEntry._parallelBabel.params).toHaveProperty('cwd');
+    });
+
+    it('all plugins from buildBabelPlugin() are serializable or have _parallelBabel', function () {
+
+      process.env.COVERAGE = 'true';
+      const require = createRequire(import.meta.url);
+      const indexPath = new URL(
+        '../packages/ember-cli-code-coverage/index.js',
+        import.meta.url
+      ).pathname;
+      delete require.cache[require.resolve(indexPath)];
+      const addon = require(indexPath);
+      const plugins = addon.buildBabelPlugin();
+
+      for (const plugin of plugins) {
+        if (typeof plugin === 'string') {
+          // String paths are serializable - load and check for _parallelBabel
+          const loaded = require(plugin);
+          expect(implementsParallelAPI(loaded)).toBe(true);
+        } else if (Array.isArray(plugin)) {
+          // [path, options] tuples with optional _parallelBabel
+          expect(typeof plugin[0]).toBe('string');
+          if (plugin._parallelBabel) {
+            expect(implementsParallelAPI(plugin)).toBe(true);
+          }
+        }
+      }
+    });
+  });
+
+  describe('multiple <template> blocks per module (.gts files)', function () {
+    it('assigns unique branchIds across templates sharing the same module name', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+      const moduleName = 'my-app/components/multi-template';
+
+      const template1 = '{{#if cond1}}yes{{else}}no{{/if}}';
+      const template2 = '{{#if cond2}}a{{else}}b{{/if}}';
+
+      const result1 = transformWithPlugin(plugin, template1, moduleName);
+      const result2 = transformWithPlugin(plugin, template2, moduleName);
+
+      const branchMap1 = extractBranchMap(result1);
+      const branchMap2 = extractBranchMap(result2);
+
+      // Template 1 should have branch 0
+      expect(Object.keys(branchMap1)).toEqual(['0']);
+
+      // Template 2 should have branch 1 (offset by template 1's count)
+      expect(Object.keys(branchMap2)).toEqual(['1']);
+    });
+
+    it('assigns unique branchIds when templates have multiple branches each', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+      const moduleName = 'my-app/components/complex';
+
+      const template1 = '{{#if a}}1{{/if}}{{#if b}}2{{else}}3{{/if}}';
+      const template2 = '{{#if c}}x{{/if}}';
+
+      const result1 = transformWithPlugin(plugin, template1, moduleName);
+      const result2 = transformWithPlugin(plugin, template2, moduleName);
+
+      const branchMap1 = extractBranchMap(result1);
+      const branchMap2 = extractBranchMap(result2);
+
+      // Template 1 has branches 0 and 1
+      expect(Object.keys(branchMap1).sort()).toEqual(['0', '1']);
+
+      // Template 2 should start at branch 2
+      expect(Object.keys(branchMap2)).toEqual(['2']);
+    });
+
+    it('does not collide branchIds in coverageMark calls', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+      const moduleName = 'my-app/components/marks';
+
+      const template1 = '{{#if a}}yes{{/if}}';
+      const template2 = '{{#if b}}no{{/if}}';
+
+      const result1 = transformWithPlugin(plugin, template1, moduleName);
+      const result2 = transformWithPlugin(plugin, template2, moduleName);
+
+      // Template 1's coverageMark should reference branch 0
+      expect(result1).toContain('coverageMark "' + moduleName + '" 0 0');
+
+      // Template 2's coverageMark should reference branch 1 (not 0)
+      expect(result2).toContain('coverageMark "' + moduleName + '" 1 0');
+    });
+
+    it('does not affect branchIds across different module names', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+
+      const template = '{{#if cond}}yes{{/if}}';
+
+      const result1 = transformWithPlugin(plugin, template, 'module-a');
+      const result2 = transformWithPlugin(plugin, template, 'module-b');
+
+      const branchMap1 = extractBranchMap(result1);
+      const branchMap2 = extractBranchMap(result2);
+
+      // Different modules should each start at 0
+      expect(Object.keys(branchMap1)).toEqual(['0']);
+      expect(Object.keys(branchMap2)).toEqual(['0']);
+    });
+
+    it('handles template with no branches followed by template with branches', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+      const moduleName = 'my-app/components/mixed';
+
+      const template1 = '<div>hello</div>';
+      const template2 = '{{#if cond}}yes{{/if}}';
+
+      const result1 = transformWithPlugin(plugin, template1, moduleName);
+      const result2 = transformWithPlugin(plugin, template2, moduleName);
+
+      // Template 1 has no branches — no coverageInit
+      expect(result1).not.toContain('coverageInit');
+
+      // Template 2 should still start at branch 0
+      const branchMap2 = extractBranchMap(result2);
+      expect(Object.keys(branchMap2)).toEqual(['0']);
+    });
+
+    it('assigns unique branchIds with inline conditionals across templates', function () {
+      const plugin = createTemplateCoveragePlugin({ coverageEnvVar: 'COVERAGE' });
+      const moduleName = 'my-app/components/inline';
+
+      const template1 = '<div class={{if a "x" "y"}}></div>';
+      const template2 = '<div class={{if b "m" "n"}}></div>';
+
+      const result1 = transformWithPlugin(plugin, template1, moduleName);
+      const result2 = transformWithPlugin(plugin, template2, moduleName);
+
+      const branchMap1 = extractBranchMap(result1);
+      const branchMap2 = extractBranchMap(result2);
+
+      expect(Object.keys(branchMap1)).toEqual(['0']);
+      expect(Object.keys(branchMap2)).toEqual(['1']);
+
+      // coverageCond in template 2 should reference branch 1
+      expect(result2).toContain('coverageCond "' + moduleName + '" 1');
+    });
+  });
+});


### PR DESCRIPTION
## Template Coverage

This addon supports branch coverage for Glimmer/Handlebars templates (`.hbs` files and `<template>` tags in `.gjs`/`.gts` files). When `COVERAGE=true`, templates are automatically instrumented during compilation to track which branches are executed.

### What is tracked

- **Block conditionals**: `{{#if}}`, `{{#unless}}` (with and without `{{else}}`)
- **Inline conditionals**: `{{if condition "yes" "no"}}`, `(if condition "a" "b")`, and the `unless` equivalents
- **List branches**: `{{#each}}`/`{{#each-in}}` with `{{else}}` (items vs empty list)
- **Chained conditionals**: `{{else if}}` chains

### How it works

A Glimmer AST plugin runs at build time and:
1. Injects `{{coverageInit}}` at the template root to register an Istanbul-compatible coverage object in `window.__coverage__`
2. Injects `{{coverageMark}}` at the start of each block branch body to record block branch hits
3. Wraps inline conditional conditions with `(coverageCond)` to record inline branch hits reactively

The coverage data integrates seamlessly with the existing Istanbul pipeline, appearing in the same HTML/LCOV/JSON reports alongside JavaScript coverage.

### Setup for .hbs files

No additional setup is needed. The AST plugin is registered automatically via `setupPreprocessorRegistry` when the addon is installed. Branch coverage for `.hbs` files works out of the box.

### Setup for .gjs/.gts files (strict mode)

For `.gjs`/`.gts` files using `<template>` tags, coverage helpers need to be in JavaScript scope. The `buildBabelPlugin()` method already includes a Babel plugin that injects the necessary imports automatically. No extra configuration is required if you already have `buildBabelPlugin()` in your `ember-cli-build.js`.